### PR TITLE
Add basic automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ all there is to it.
 That means that to add a new module to script-modules, all you have to do is include an `install.sh` script and it'll
 automatically be installable!
 
+## Running tests
+
+The tests for this repo are defined in the `test` folder. They are designed to run in a Docker container so that you
+do not repeatedly dirty up your local OS while testing. We've defined a `test/docker-compose.yml` file as a convenient
+way to expose the environment variables we need for testing and to mount local directories as volumes for rapid
+iteration.
+
+To run the tests:
+
+1. Set your [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) as
+   the environment variable `GITHUB_OAUTH_TOKEN`.
+1. `./_ci/run-tests.sh`
+
 ## Is it safe to pipe URLs into bash?
 
 Are you worried that our install instructions tell you to pipe a URL into bash? Although this approach has seen some
@@ -143,4 +156,3 @@ that'll happen when you execute it is a harmless syntax error.
 
 1. Add support for a `--version` flag to `bootstrap-gruntwork-installer.sh` and `gruntwork-install`.
 1. Configure a CI build to automatically set the `--version` flag for each release.
-1. Add automated tests for this repo.

--- a/README.md
+++ b/README.md
@@ -156,3 +156,4 @@ that'll happen when you execute it is a harmless syntax error.
 
 1. Add support for a `--version` flag to `bootstrap-gruntwork-installer.sh` and `gruntwork-install`.
 1. Configure a CI build to automatically set the `--version` flag for each release.
+1. Add an `uninstall` command that uses an `uninstall.sh` script in each module.

--- a/_ci/run-tests.sh
+++ b/_ci/run-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Runs the automated tests for this repo
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "Building docker container for test"
+docker build -t gruntwork/gruntwork-installer test
+
+echo "Running integration tests using docker-compose"
+docker-compose -f test/docker-compose.yml run installer /test/integration-test.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  services:
+    - docker
+
+test:
+  override:
+    - ./_ci/run-tests.sh

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -88,9 +88,11 @@ function fetch_script_module {
 function validate_module {
   local readonly module_name="$1"
   local readonly download_path="$2"
+  local readonly tag="$3"
+  local readonly branch="$4"
 
   if [[ ! -e "$download_path/$module_name" ]]; then
-    echo "ERROR: No files were downloaded. Are you sure \"$module_name\" is a valid Script Module in $SCRIPT_MODULES_REPO?"
+    echo "ERROR: No files were downloaded. Are you sure \"$module_name\" is a valid Script Module in $SCRIPT_MODULES_REPO (tag = $tag, branch = $branch)?"
     exit 1
   fi
 }
@@ -170,7 +172,7 @@ function install_script_module {
 
   echo "Installing $module_name..."
   fetch_script_module "$module_name" "$tag" "$branch" "$GITHUB_OAUTH_TOKEN" "$MODULES_DOWNLOAD_DIR"
-  validate_module "$module_name" "$MODULES_DOWNLOAD_DIR"
+  validate_module "$module_name" "$MODULES_DOWNLOAD_DIR" "$tag" "$branch"
   run_module "$module_name" "${module_params[@]}"
   echo "Success!"
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 RUN apt-get update

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu
+MAINTAINER Gruntwork <info@gruntwork.io>
+
+RUN apt-get update
+RUN apt-get install -y curl sudo
+
+COPY . /test
+
+CMD ["echo", "This container is used for testing. Consider running one of the test scripts under the /test folder."]

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,7 @@
+installer:
+  image: gruntwork/gruntwork-installer
+  volumes:
+    - ../:/src
+    - .:/test
+  environment:
+    - GITHUB_OAUTH_TOKEN

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,7 +1,10 @@
 installer:
   image: gruntwork/gruntwork-installer
   volumes:
+    # Mount the scripts in the root directory under /src
     - ../:/src
+    # Mount the test code in this directory under /test
     - .:/test
   environment:
+    # Forward the GITHUB_OAUTH_TOKEN as an environment variable from the user's environment
     - GITHUB_OAUTH_TOKEN

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Some basic automated tests for gruntwork-installer
+
+set -e
+
+readonly LOCAL_INSTALL_URL="file:///src/gruntwork-install"
+
+echo "Using local copy of bootstrap installer to install local copy of gruntwork-install"
+./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
+
+echo "Using gruntwork-install to install a few modules from script-modules"
+gruntwork-install --module-name "vault-ssh-helper" --tag "~>0.0.21"
+


### PR DESCRIPTION
This PR adds a very basic level of automated tests to the Gruntwork installer. It runs a bare-minimum-end-to-end integration test: run the bootstrap script to install `gruntwork-install` and then run `gruntwork-install` to install a module from script-modules. 

The tests run in a Docker container to keep your local environment clean.