### PR TITLE
Add support for installing binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # Gruntwork Installer
 
-At [Gruntwork](http://www.gruntwork.io/), we've developed a number of scripts and apps, most of them in private repos
-such as [script-modules](https://github.com/gruntwork-io/script-modules), that perform common infrastructure tasks such
-as setting up continuous integration, monitoring, log aggregation, and SSH access. This repo provides a script called
-`gruntwork-install` that makes it as easy to install a Gruntwork script from a private repo as using apt-get, brew, or
-yum.
+At [Gruntwork](http://www.gruntwork.io/), we've developed a number of scripts and binaries, most of them in private
+repos, that perform common infrastructure tasks such as setting up continuous integration, monitoring, log aggregation,
+and SSH access. This repo provides a script called `gruntwork-install` that makes it as easy to install Gruntwork
+scripts and binaries as using apt-get, brew, or yum.
 
-For example, in your Packer and Docker templates, you can use `gruntwork-install` to install the [vault-ssh-helper
-module](https://github.com/gruntwork-io/script-modules/tree/master/modules/vault-ssh-helper) as follows:
+For example, in your Packer and Docker templates, you can use `gruntwork-install` to install the [ecs-scripts
+module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) as follows:
 
-```bash
-gruntwork-install --module-name 'vault-ssh-helper' --tag '0.0.3'
+```
+gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'
 ```
 
 ## Installing gruntwork-install
 
-```bash
-curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.7
+```
+curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.11
 ```
 
 Notice the `--version` parameter at the end where you specify which version of `gruntwork-install` to install. See the
@@ -28,11 +27,11 @@ For paranoid security folks, see [is it safe to pipe URLs into bash?](#is-it-saf
 
 #### Authentication
 
-To install scripts from private Gruntwork repos, you must create a [GitHub access
+To install scripts and binaries from private Gruntwork repos, you must create a [GitHub access
 token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) and set it as the environment
 variable `GITHUB_OAUTH_TOKEN` so `gruntwork-install` can use it to access the repo:
 
-```bash
+```
 export GITHUB_OAUTH_TOKEN="(your secret token)"
 ```
 
@@ -42,37 +41,43 @@ Once that environment variable is set, you can run `gruntwork-install` with the 
 
 Option           | Required | Description
 ---------------- | -------- | ------------
-`--module-name`  | Yes      | The name of the Script Module to install. Can be any folder within the `modules` directory of the [Script Modules Repo](https://github.com/gruntwork-io/script-modules).
-`--tag`          | Yes      | The version of the Script Module to install. Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
+`--repo`         | Yes      | The GitHub repo to install from.
+`--tag`          | Yes      | The version of the `--repo` to install from. Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
+`--module-name`  | No       | The name of a module to install. Can be any folder within the `modules` directory of `--repo`. You must specify exactly one of `--module-name` or `--binary-name`.
+`--binary-name`  | No       | The name of a binary to install. Can be any file uploaded as a release asset in `--repo`.  You must specify exactly one of `--module-name` or `--binary-name`.
 `--module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module as a parameter. May be used multiple times. See the documentation for each module to find out what parameters it accepts.
-`--repo`         | No       | `gruntwork-install` assumes that all scripts are in the [script-modules](https://github.com/gruntwork-io/script-modules) repo. To use a different repo, specify the `--repo` flag.
 `--help`         | No       | Show the help text and exit.
 
 #### Examples
 
-Install the [cloudwatch-log-aggregation
-module](https://github.com/gruntwork-io/script-modules/tree/master/modules/cloudwatch-log-aggregation) version `0.0.3`:
+Install the [ecs-scripts
+module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) from the [module-ecs
+repo](https://github.com/gruntwork-io/module-ecs), version `0.0.1`:
 
-```bash
-gruntwork-install --module-name 'cloudwatch-log-aggregation' --tag '0.0.3'
+```
+gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'
 ```
 
 Install the [vault-ssh-helper
-module](https://github.com/gruntwork-io/script-modules/tree/master/modules/vault-ssh-helper), passing two custom
-parameters to it:
+module](https://github.com/gruntwork-io/script-modules/tree/master/modules/vault-ssh-helper) from the [script-modules
+repo](https://github.com/gruntwork-io/script-modules), passing two custom parameters to it:
 
-```bash
-gruntwork-install --module-name 'vault-ssh-helper' --tag '0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'
+```
+gruntwork-install --module-name 'vault-ssh-helper' --repo 'https://github.com/gruntwork-io/script-modules' --tag '0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'
 ```
 
-Install [ecs-scripts](https://github.com/gruntwork-io/module-ecs/tree/master/modules/scripts) from the
-[module-ecs repo](https://github.com/gruntwork-io/module-ecs):
+Install the `gruntkms` binary from the `v0.0.1` release of the [gruntkms
+repo](https://github.com/gruntwork-io/gruntkms):
 
-```bash
-gruntwork-install --module-name 'ecs-scripts' --tag '0.0.3' --repo "https://github.com/gruntwork-io/module-ecs"
+```
+gruntwork-install --binary-name 'gruntkms' --repo 'https://github.com/gruntwork-io/gruntkms' --tag 'v0.0.1'
 ```
 
-And finally, to put all the pieces together, here is an example of a Packer template that installs `gruntwork-install`
+Note that the [v0.0.1 release of the gruntkms repo](https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.1) has
+multiple binaries (`gruntkms_linux_amd64`, `gruntkms_darwin_386`, etc): `gruntwork-install` automatically picks the
+right binary for your OS and copies it to `/usr/local/bin/gruntkms`.
+
+Finally, to put all the pieces together, here is an example of a Packer template that installs `gruntwork-install`
 and then uses it to install several modules:
 
 ```json
@@ -90,13 +95,13 @@ and then uses it to install several modules:
   }],
   "provisioners": [{
     "type": "shell",
-    "inline": "curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.6"
+    "inline": "curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.11"
   },{
     "type": "shell",
     "inline": [
-      "gruntwork-install --module-name 'vault-ssh-helper' --tag '~>0.0.4' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'",
-      "gruntwork-install --module-name 'cloudwatch-log-aggregation' --tag '~>0.0.4'",
-      "gruntwork-install --module-name 'build-helpers' --tag '~>0.0.4'"
+      "gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'",
+      "gruntwork-install --module-name 'vault-ssh-helper' --repo 'https://github.com/gruntwork-io/script-modules' --tag '0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'",
+      "gruntwork-install --binary-name 'gruntkms' --repo 'https://github.com/gruntwork-io/gruntkms' --tag 'v0.0.1'"
     ],
     "environment_vars": [
       "GITHUB_OAUTH_TOKEN={{user `github_auth_token`}}"
@@ -107,18 +112,21 @@ and then uses it to install several modules:
 
 ## How Gruntwork modules work
 
-`gruntwork-install` is a fairly simple script that does the following:
+`gruntwork-install` does the following:
 
-1. Uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module from the
-   `/modules` folder of either the [script-modules](https://github.com/gruntwork-io/script-modules) repo or the repo
-   specified via the `--repo` option.
-1. Runs the `install.sh` script inside that module.
+1. Uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module or binary from
+   the repo specified via the `--repo` option.
+1. If you used the `--module-name` parameter, it downloads the module from the `modules` folder of `--repo` and runs
+   the `install.sh` script of that module.
+1. If you used the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
+   and gives it execute permissions.
 
 Future versions of `gruntwork-install` may do more (e.g. verify checksums, manage dependencies), but for now, that's
 all there is to it.
 
-That means that to add a new module, all you have to do is include an `install.sh` script and it'll automatically be
-installable!
+That means that to create an installable module, all you have to do is put it in the `modules` folder and include an
+`install.sh` script; to create an installable binary, you just publish it to a GitHub release with the name format
+`<NAME>_<OS>_<ARCH>`.
 
 ## Running tests
 

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -9,11 +9,11 @@
 
 set -e
 
-readonly SCRIPT_MODULES_REPO="https://github.com/gruntwork-io/script-modules"
 readonly MODULES_DIR="modules"
+readonly MODULE_INSTALL_FILE_NAME="install.sh"
 
 readonly MODULES_DOWNLOAD_DIR="/tmp/gruntwork-script-modules"
-readonly MODULE_INSTALL_FILE_NAME="install.sh"
+readonly BINARY_DOWNLOAD_DIR="/usr/local/bin"
 
 function print_usage {
   echo
@@ -23,15 +23,17 @@ function print_usage {
   echo
   echo "Options:"
   echo
-  echo -e "  --module-name\t\tRequired. The name of the module to install. Can be any folder within the $MODULES_DIR directory of the --repo option."
-  echo -e "  --tag\t\t\tRequired. The version of the module to install. Follows the syntax described at https://github.com/gruntwork-io/fetch#tag-constraint-expressions."
-  echo -e "  --branch\t\tOptional. Download the latest commit from this branch in --repo. This is an alternative to --tag for development purposes."
-  echo -e "  --repo\t\tOptional. The repo to download modules from. If not specified, defaults to $SCRIPT_MODULES_REPO."
+  echo -e "  --repo\t\Required. The repo to install from."
+  echo -e "  --tag\t\t\tRequired. The version of --repo to install. Follows the syntax described at https://github.com/gruntwork-io/fetch#tag-constraint-expressions."
+  echo -e "  --module-name\t\tOptional. The name of a module to install. Can be any folder within the $MODULES_DIR directory of --repo. You must specify exactly one of --module-name or --binary-name."
+  echo -e "  --binary-name\t\tOptional. The name of a binary to install. Can be any file uploaded as a release asset in --repo.  You must specify exactly one of --module-name or --binary-name."
+  echo -e "  --branch\t\tOptional. Download the latest commit from this branch in --repo. This is an alternative to --tag, used only for testing."
   echo -e "  --module-param\tOptional. A key-value pair of the format key=value you wish to pass to the module as a parameter. May be used multiple times."
+  echo -e "  --help\t\Show this help text and exit."
   echo
   echo "Example:"
   echo
-  echo "  gruntwork-install --module-name 'vault-ssh-helper' --tag '~>0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'"
+  echo "  gruntwork-install --module-name 'vault-ssh-helper' --repo 'https://github.com/gruntwork-io/script-modules' --tag '~>0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'"
   echo
 }
 
@@ -71,9 +73,8 @@ function fetch_script_module {
   local readonly module_name="$1"
   local readonly tag="$2"
   local readonly branch="$3"
-  local readonly github_token="$4"
-  local readonly download_path="$5"
-  local readonly repo="$6"
+  local readonly download_path="$4"
+  local readonly repo="$5"
 
   # We want to make sure that all folders down to $download_path/$module_name exists, but that $download_path/$module_name itself is empty.
   mkdir -p "$download_path/$module_name/"
@@ -81,9 +82,36 @@ function fetch_script_module {
 
   # Note that fetch can safely handle blank arguments for --tag or --branch
   # If both --tag and --branch are specified, --branch will be used
-  # TODO: fetch should read GITHUB_OAUTH_TOKEN as an environment variable too
   echo "Downloading module $module_name from $repo"
-  fetch --repo="$repo" --tag="$tag" --branch="$branch" --github-oauth-token="$github_token" "/modules/$module_name" "$download_path/$module_name" >/dev/null
+  fetch --repo="$repo" --tag="$tag" --branch="$branch" --source-path="/modules/$module_name" "$download_path/$module_name"
+}
+
+# Download a binary asset from a GitHub release using fetch (https://github.com/gruntwork-io/fetch)
+function fetch_binary {
+  local readonly binary_name="$1"
+  local readonly tag="$2"
+  local readonly download_path="$3"
+  local readonly repo="$4"
+
+  local binary_name_full=""
+  binary_name_full=$(determine_binary_name "$binary_name")
+
+  # We want to make sure that all folders down to $download_path exist, but that $download_path/$binary_name_full does not
+  mkdir -p "$download_path"
+  rm -f "$download_path/$binary_name_full"
+
+  # Use fetch to download the binary and then move it to its final destination
+  fetch --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_path"
+  mv "$download_path/$binary_name_full" "$download_path/$binary_name"
+}
+
+function set_binary_permissions {
+  local readonly binary_name="$1"
+  local readonly download_path="$2"
+  local readonly full_path="$download_path/$binary_name"
+
+  echo "Setting execute permissions for $full_path"
+  chmod u+x "$full_path"
 }
 
 # Validate that at least one file was downloaded from the module; otherwise throw an error.
@@ -98,6 +126,47 @@ function validate_module {
     echo "ERROR: No files were downloaded. Are you sure \"$module_name\" is a valid Script Module in $repo (tag = $tag, branch = $branch)?"
     exit 1
   fi
+}
+
+# http://stackoverflow.com/a/2264537/483528
+function to_lower_case {
+  tr '[:upper:]' '[:lower:]'
+}
+
+function get_os_name {
+  uname | to_lower_case
+}
+
+function get_os_arch {
+  uname -m
+}
+
+function string_contains {
+  local readonly str="$1"
+  local readonly contains="$2"
+
+  [[ "$str" == *"$contains"* ]]
+}
+
+function get_os_arch_gox_format {
+  local readonly arch=$(get_os_arch)
+
+  if $(string_contains "$arch" "64"); then
+    echo "amd64"
+  elif $(string_contains "$arch" "386"); then
+    echo "386"
+  elif $(string_contains "$arch" "arm"); then
+    echo "arm"
+  fi
+}
+
+# We release binaries with the name following the format <NAME>_<OS>_<ARCH> (e.g. foo_linux_amd64). Given the NAME of
+# a binary, this function adds the proper OS and ARCH to it for the current OS.
+function determine_binary_name {
+  local readonly binary_name="$1"
+  local readonly os_name=$(get_os_name)
+  local readonly os_arch=$(get_os_arch_gox_format)
+  echo "${binary_name}_${os_name}_${os_arch}"
 }
 
 # Take in a key-value pair of the format key=value and convert it to the format that Gruntwork bash scripts expect:
@@ -122,7 +191,8 @@ function install_script_module {
   local tag=""
   local branch=""
   local module_name=""
-  local repo="$SCRIPT_MODULES_REPO"
+  local binary_name=""
+  local repo=""
   local module_params=()
 
   while [[ $# > 0 ]]; do
@@ -139,6 +209,10 @@ function install_script_module {
         ;;
       --module-name)
         module_name="$2"
+        shift
+        ;;
+      --binary-name)
+        binary_name="$2"
         shift
         ;;
       --repo)
@@ -165,14 +239,30 @@ function install_script_module {
   done
 
   assert_is_installed fetch
-  assert_not_empty "--module-name" "$module_name"
-  assert_not_empty "--repo" "$repo"
   assert_env_var_not_empty "GITHUB_OAUTH_TOKEN"
+  assert_not_empty "--repo" "$repo"
 
-  echo "Installing $module_name..."
-  fetch_script_module "$module_name" "$tag" "$branch" "$GITHUB_OAUTH_TOKEN" "$MODULES_DOWNLOAD_DIR" "$repo"
-  validate_module "$module_name" "$MODULES_DOWNLOAD_DIR" "$tag" "$branch" "$repo"
-  run_module "$module_name" "${module_params[@]}"
+  if [[ ( -z "$module_name" && -z "$binary_name" ) || ( ! -z "$module_name" && ! -z "$binary_name" ) ]]; then
+    echo "ERROR: You must specify exactly one of --module-name or --binary-name."
+    exit 1
+  fi
+
+  if [[ ! -z "$binary_name" && -z "$tag" ]]; then
+    echo "ERROR: --binary-name can only be used if you specify a release via --tag."
+    exit 1
+  fi
+
+  if [[ ! -z "$module_name" ]]; then
+    echo "Installing from $module_name..."
+    fetch_script_module "$module_name" "$tag" "$branch" "$MODULES_DOWNLOAD_DIR" "$repo"
+    validate_module "$module_name" "$MODULES_DOWNLOAD_DIR" "$tag" "$branch" "$repo"
+    run_module "$module_name" "${module_params[@]}"
+  else
+    echo "Installing $binary_name..."
+    fetch_binary "$binary_name" "$tag" "$BINARY_DOWNLOAD_DIR" "$repo"
+    set_binary_permissions "$binary_name" "$BINARY_DOWNLOAD_DIR"
+  fi
+
   echo "Success!"
 }
 

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -10,7 +10,19 @@ echo "Using local copy of bootstrap installer to install local copy of gruntwork
 ./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
 
 echo "Using gruntwork-install to install a few modules from script-modules"
-gruntwork-install --module-name "vault-ssh-helper" --tag "~>0.0.21"
+gruntwork-install --module-name "vault-ssh-helper" --repo "https://github.com/gruntwork-io/script-modules" --tag "~>0.0.21"
+
+echo "Checking that the vault-ssh-helper installed correctly"
+/etc/user-data/vault-ssh-helper/download-ca-cert.sh --help
 
 echo "Using gruntwork-install to install a module from the module-ecs repo"
 gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1"
+
+echo "Checking that the ecs-scripts installed correctly"
+configure-ecs-instance --help
+
+echo "Using gruntwork-install to install a binary from the gruntkms repo"
+gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-io/gruntkms" --tag "v0.0.1"
+
+echo "Checking that gruntkms installed correctly"
+gruntkms --help


### PR DESCRIPTION
This PR allows `gruntwork-install` to install not only source folders under a `modules` directory in GitHub, but also binaries assets uploaded to a GitHub release.

This also removes the script-modules repo as the default, since we are actively moving everything out of it and actually prefer that it's not used anymore. Since `gruntwork-install` is versioned, this shouldn't affect any existing users.