### PR TITLE
Add packer-file-copy script module and rewrite main README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,43 @@
 # Gruntwork Installer
 
-`gruntwork-install` is a bash script you run to easily download and install "script modules" written by Gruntwork. 
+`gruntwork-install` is a bash script you run to easily download and install "Script Modules" written by Gruntwork. 
 
-A script module is a package of one or more bash scripts and/or binaries maintained by Gruntwork that are meant to be 
-reusable in many different contexts. For example, we have script modules for installing a CloudWatch Logs agent, optimizing
+### Script Modules
+
+A Script Module is a package of one or more bash scripts and/or binaries maintained by Gruntwork that are meant to be 
+reusable in many different contexts. For example, we have Script Modules for installing a CloudWatch Logs agent, optimizing
 syslog settings, setting up automatic security updates, and more. 
 
-Our script modules are contained in the `modules/` folder of different GitHub repos since they often come with the 
+Our Script Modules are contained in the `modules/` folder of different GitHub repos since they often come with the 
 different [Infrastructure Packages](https://blog.gruntwork.io/gruntwork-infrastructure-packages-7434dc77d0b1#.6bwor6wxc) 
 we sell.
+
+#### Common Script Modules
+
+Some Script Modules are so common that we've made them freely available in the [modules/](modules) folder of this repo.
 
 ### Motivation
 At [Gruntwork](http://www.gruntwork.io/), we've developed a number of scripts and binaries, most of them in private GitHub
 repos, that perform common infrastructure tasks such as setting up continuous integration, monitoring, log aggregation,
-and SSH access. Being able to use these "modules" of code typically involves many steps, you download the files 
+and SSH access. Being able to use these "modules" of code typically involves many steps: you download the files 
 (possibly from a private GitHub repo), change their permissions, and run them with the parameters that make sense for 
 your environment.
 
-That's a lot of steps, and just means lots of `bash` code copied differently across multiple software teams. Worse, if we 
-want to update a script to add a new parameter, each team has to see how they've written the code to "install" the module, 
-and update it in the right spot. We believe we can do better by making our script modules as easy to install as a typical package 
-using `apt-get`, `yum`, `npm`, or similar tools.
+That basically means lots of custom `bash` code copied differently across multiple software teams. Worse, if we 
+want to update a binary or script to add a new parameter, each team has to modify their own custom code, which can be 
+painful. 
 
-So we wrote a bash script named `gruntwork-install` that installs any Gruntwork script module.  
+We believe we can do better by writing our scripts and binaries in a standardized way, and including a minimal tool that 
+streamlines the process of downloading and installing them. Indeed, our goal is to make installing Gruntwork Script 
+Modules as easy as installing a typical package using `apt-get`, `yum`, `npm`, or similar tools. And since we give you 
+100% of the source code, we want it to be clear exactly what happens when you install a Gruntwork Script Module.  
 
 ### How `gruntwork-install` Works
 
-We've made it transparent what it means to "install" a module:
+To actually install a Gruntwork Script Module, we wrote a bash script named `gruntwork-install`. Here's how it works:
 
-1. We use [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module or binary from
-   the repo specified via the `--repo` option.
+1. It uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module or binary from
+   the (public or private) git repo specified via the `--repo` option.
 1. If you used the `--module-name` parameter, it downloads the module from the `modules` folder of `--repo` and runs
    the `install.sh` script of that module.
 1. If you used the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
@@ -50,17 +58,17 @@ module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scrip
 gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'
 ```
 
-In https://github.com/gruntwork-io/module-ecs, we download the contents of `/modules/ecs-scripts` and run `/modules/esc-scripts/install.sh`.
+In https://github.com/gruntwork-io/module-ecs, we download the contents of `/modules/ecs-scripts` and run 
+`/modules/esc-scripts/install.sh`.
 
 ## Quick Start
 
 ### Install gruntwork-install
 
-If `gruntwork-install` is our approach for installing script modules, how do we install `gruntwork-install` itself? Our
-solution is to make the `gruntwork-install` tool open source and to publish a `bootstrap-gruntwork-installer.sh` script
-that anyone can use to install `gruntwork-install` itself.
+If `gruntwork-install` is our approach for installing Script Modules, how do we install `gruntwork-install` itself? 
 
-To use it, execute the following:
+Our solution is to make the `gruntwork-install` tool open source and to publish a `bootstrap-gruntwork-installer.sh` 
+script that anyone can use to install `gruntwork-install` itself. To use it, execute the following:
 
 ```
 curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.11
@@ -75,7 +83,7 @@ For paranoid security folks, see [is it safe to pipe URLs into bash?](#is-it-saf
 
 #### Authentication
 
-To install scripts and binaries from private Gruntwork repos, you must create a [GitHub access
+To install scripts and binaries from private GitHub repos, you must create a [GitHub access
 token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) and set it as the environment
 variable `GITHUB_OAUTH_TOKEN` so `gruntwork-install` can use it to access the repo:
 
@@ -87,14 +95,14 @@ export GITHUB_OAUTH_TOKEN="(your secret token)"
 
 Once that environment variable is set, you can run `gruntwork-install` with the following options:
 
-Option         | Required | Description
--------------- | -------- | ------------
-`repo`         | Yes      | The GitHub repo to install from.
-`tag`          | Yes      | The version of the `--repo` to install from. Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
-`module-name`  | XOR      | The name of a module to install. Can be any folder within the `modules` directory of `--repo`. You must specify exactly one of `--module-name` or `--binary-name`.
-`binary-name`  | XOR      | The name of a binary to install. Can be any file uploaded as a release asset in `--repo`.  You must specify exactly one of `--module-name` or `--binary-name`.
-`module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module as a parameter. May be used multiple times. See the documentation for each module to find out what parameters it accepts.
-`help`         | No       | Show the help text and exit.
+Option           | Required | Description
+---------------- | -------- | ------------
+`--repo`         | Yes      | The GitHub repo to install from.
+`--tag`          | Yes      | The version of the `--repo` to install from.<br>Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
+`--module-name`  | XOR      | The name of a module to install.<br>Can be any folder within the `modules` directory of `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
+`--binary-name`  | XOR      | The name of a binary to install.<br>Can be any file uploaded as a release asset in `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
+`--module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module<br>as a parameter. May be used multiple times.<br>See the documentation for each module to find out what parameters it accepts.
+`--help`         | No       | Show the help text and exit.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # Gruntwork Installer
 
-`gruntwork-install` is a bash script you run to easily download and install "Script Modules" written by Gruntwork. 
+`gruntwork-install` is a bash script you run to easily download and install "Gruntwork Modules." 
 
-### Script Modules
+### Gruntwork Modules
 
-A Script Module is a package of one or more bash scripts and/or binaries maintained by Gruntwork that are meant to be 
-reusable in many different contexts. For example, we have Script Modules for installing a CloudWatch Logs agent, optimizing
-syslog settings, setting up automatic security updates, and more. 
+A Gruntwork Module is a collection of one or more bash scripts and/or binaries maintained by Gruntwork that can be used to 
+add functionality to or configure an environment. There are multiple types of Gruntwork Modules:
 
-Our Script Modules are contained in the `modules/` folder of different GitHub repos since they often come with the 
-different [Infrastructure Packages](https://blog.gruntwork.io/gruntwork-infrastructure-packages-7434dc77d0b1#.6bwor6wxc) 
-we sell.
+- **Script Modules:** A collection of one or more files and scripts; installed with an `install.sh` script.
+- **Binary Modules:** A single OS-specific executable binary.
 
-#### Common Script Modules
+Additional module types may be introduced in the future.
+
+As an example, we have Script Modules for installing a CloudWatch Logs agent, optimizing syslog settings, and setting up 
+automatic security updates. We have a Binary Module for streamlining the use of Amazon Key Management Service (KMS).
+
+Gruntwork sells [Infrastructure Packages](https://blog.gruntwork.io/gruntwork-infrastructure-packages-7434dc77d0b1#.6bwor6wxc).
+Each Infrastructure Package corresponds to a specific GitHub repo and contains one or more Gruntwork Modules. The `/modules`
+folder in the repo lists all Modules included with that Package.
+
+#### Freely Available Script Modules
 
 Some Script Modules are so common that we've made them freely available in the [modules/](modules) folder of this repo.
 
@@ -23,35 +30,38 @@ and SSH access. Being able to use these "modules" of code typically involves man
 (possibly from a private GitHub repo), change their permissions, and run them with the parameters that make sense for 
 your environment.
 
-That basically means lots of custom `bash` code copied differently across multiple software teams. Worse, if we 
-want to update a binary or script to add a new parameter, each team has to modify their own custom code, which can be 
-painful. 
+That basically means lots of custom `bash` code copied differently across multiple software teams in multiple different
+contexts. Worse, if we want to update a binary or script to add a new parameter, each team has to modify their own custom 
+code, which can be painful. 
 
 We believe we can do better by writing our scripts and binaries in a standardized way, and including a minimal tool that 
-streamlines the process of downloading and installing them. Also, installation should be streamlined no matter what 
-platform (Windows, MacOS, Linux) you're on. 
-
-Indeed, our goal is to make installing Gruntwork Script  Modules as easy as installing a typical package using `apt-get`, 
-`yum`, `npm`, or similar tools. We would have just used these existing tools, but none offer multi-platform compatibility.
-Finally, since we give you 100% of the source code, we want it to be clear exactly what happens when you install a 
-Gruntwork Script Module.  
+streamlines the process of downloading and installing them. Also, since we give you 100% of the source code, we want it 
+to be clear exactly what happens when you install a Gruntwork Module.  
+ 
+Finally, installation should be streamlined no matter what platform (Windows, MacOS, Linux) you're on. Indeed, our goal 
+is to make installing Gruntwork Script  Modules as easy as installing a typical package using `apt-get`, `yum`, `npm`, 
+or similar tools. We would have just used these existing tools, but none offer multi-platform compatibility.
 
 ### How `gruntwork-install` Works
 
-To actually install a Gruntwork Script Module, we wrote a bash script named `gruntwork-install`. Here's how it works:
+To actually install a Gruntwork Module, we wrote a bash script named `gruntwork-install`. Here's how it works:
 
-1. It uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module or binary from
+1. It uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the scripts or binary from
    the (public or private) git repo specified via the `--repo` option.
-1. If you used the `--module-name` parameter, it downloads the module from the `modules` folder of `--repo` and runs
+1. If you used the `--module-name` parameter, it downloads the files from the `modules` folder of `--repo` and runs
    the `install.sh` script of that module.
 1. If you used the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
    and gives it execute permissions.
 
 That's it!
 
-That means that to create an installable module, all you have to do is put it in the `modules` folder and include an
-`install.sh` script; to create an installable binary, you just publish it to a GitHub release with the name format
-`<NAME>_<OS>_<ARCH>`. 
+#### Create Your Own Gruntwork Modules
+
+You can use `gruntwork-install` with any GitHub repo, not just repos maintained by Gruntwork.
+
+That means that to create an installable Script Module, all you have to do is put it in the `modules` folder of
+a GitHub repo to which you have access and include an `install.sh` script. To create a Binary Module, you just publish 
+it to a GitHub release with the name format `<NAME>_<OS>_<ARCH>`. 
 
 ### Example 
 
@@ -69,7 +79,7 @@ In https://github.com/gruntwork-io/module-ecs, we download the contents of `/mod
 
 ### Install gruntwork-install
 
-If `gruntwork-install` is our approach for installing Script Modules, how do we install `gruntwork-install` itself? 
+If `gruntwork-install` is our approach for installing Gruntwork Modules, how do we install `gruntwork-install` itself? 
 
 Our solution is to make the `gruntwork-install` tool open source and to publish a `bootstrap-gruntwork-installer.sh` 
 script that anyone can use to install `gruntwork-install` itself. To use it, execute the following:
@@ -105,12 +115,12 @@ Option           | Required | Description
 `--tag`          | Yes      | The version of the `--repo` to install from.<br>Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
 `--module-name`  | XOR      | The name of a module to install.<br>Can be any folder within the `modules` directory of `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
 `--binary-name`  | XOR      | The name of a binary to install.<br>Can be any file uploaded as a release asset in `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
-`--module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module as a parameter.<br>May be used multiple times.<br>See the documentation for each module to find out what parameters it accepts.
+`--module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the<br> module as a parameter. May be used multiple times.<br>See the documentation for each module to find out what parameters it accepts.
 `--help`         | No       | Show the help text and exit.
 
 #### Examples
 
-##### Example 1: Download and Install a Module with No Parameters
+##### Example 1: Download and Install a Script Module with No Parameters
 
 Install the [ecs-scripts
 module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) from the [module-ecs
@@ -120,7 +130,7 @@ repo](https://github.com/gruntwork-io/module-ecs), version `0.0.1`:
 gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'
 ```
 
-##### Example 2: Download and Install a Module with Parameters
+##### Example 2: Download and Install a Script Module with Parameters
 
 Install the [vault-ssh-helper
 module](https://github.com/gruntwork-io/script-modules/tree/master/modules/vault-ssh-helper) from the [script-modules
@@ -130,7 +140,7 @@ repo](https://github.com/gruntwork-io/script-modules), passing two custom parame
 gruntwork-install --module-name 'vault-ssh-helper' --repo 'https://github.com/gruntwork-io/script-modules' --tag '0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'
 ```
 
-##### Example 3: Download and Install a Binary 
+##### Example 3: Download and Install a Binary Module 
 
 Install the `gruntkms` binary from the `v0.0.1` release of the [gruntkms
 repo](https://github.com/gruntwork-io/gruntkms):

--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
 # Gruntwork Installer
 
-At [Gruntwork](http://www.gruntwork.io/), we've developed a number of scripts and binaries, most of them in private
+`gruntwork-install` is a bash script you run to easily download and install "script modules" written by Gruntwork. 
+
+A script module is a package of one or more bash scripts and/or binaries maintained by Gruntwork that are meant to be 
+reusable in many different contexts. For example, we have script modules for installing a CloudWatch Logs agent, optimizing
+syslog settings, setting up automatic security updates, and more. 
+
+Our script modules are contained in the `modules/` folder of different GitHub repos since they often come with the 
+different [Infrastructure Packages](https://blog.gruntwork.io/gruntwork-infrastructure-packages-7434dc77d0b1#.6bwor6wxc) 
+we sell.
+
+### Motivation
+At [Gruntwork](http://www.gruntwork.io/), we've developed a number of scripts and binaries, most of them in private GitHub
 repos, that perform common infrastructure tasks such as setting up continuous integration, monitoring, log aggregation,
-and SSH access. This repo provides a script called `gruntwork-install` that makes it as easy to install Gruntwork
-scripts and binaries as using apt-get, brew, or yum.
+and SSH access. Being able to use these "modules" of code typically involves many steps, you download the files 
+(possibly from a private GitHub repo), change their permissions, and run them with the parameters that make sense for 
+your environment.
+
+That's a lot of steps, and just means lots of `bash` code copied differently across multiple software teams. Worse, if we 
+want to update a script to add a new parameter, each team has to see how they've written the code to "install" the module, 
+and update it in the right spot. We believe we can do better by making our script modules as easy to install as a typical package 
+using `apt-get`, `yum`, `npm`, or similar tools.
+
+So we wrote a bash script named `gruntwork-install` that installs any Gruntwork script module.  
+
+### How `gruntwork-install` Works
+
+We've made it transparent what it means to "install" a module:
+
+1. We use [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module or binary from
+   the repo specified via the `--repo` option.
+1. If you used the `--module-name` parameter, it downloads the module from the `modules` folder of `--repo` and runs
+   the `install.sh` script of that module.
+1. If you used the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
+   and gives it execute permissions.
+
+That's it!
+
+That means that to create an installable module, all you have to do is put it in the `modules` folder and include an
+`install.sh` script; to create an installable binary, you just publish it to a GitHub release with the name format
+`<NAME>_<OS>_<ARCH>`. 
+
+### Example 
 
 For example, in your Packer and Docker templates, you can use `gruntwork-install` to install the [ecs-scripts
 module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) as follows:
@@ -12,7 +50,17 @@ module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scrip
 gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'
 ```
 
-## Installing gruntwork-install
+In https://github.com/gruntwork-io/module-ecs, we download the contents of `/modules/ecs-scripts` and run `/modules/esc-scripts/install.sh`.
+
+## Quick Start
+
+### Install gruntwork-install
+
+If `gruntwork-install` is our approach for installing script modules, how do we install `gruntwork-install` itself? Our
+solution is to make the `gruntwork-install` tool open source and to publish a `bootstrap-gruntwork-installer.sh` script
+that anyone can use to install `gruntwork-install` itself.
+
+To use it, execute the following:
 
 ```
 curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.11
@@ -23,7 +71,7 @@ Notice the `--version` parameter at the end where you specify which version of `
 
 For paranoid security folks, see [is it safe to pipe URLs into bash?](#is-it-safe-to-pipe-urls-into-bash) below.
 
-## Using gruntwork-install
+### Use gruntwork-install
 
 #### Authentication
 
@@ -43,12 +91,14 @@ Option         | Required | Description
 -------------- | -------- | ------------
 `repo`         | Yes      | The GitHub repo to install from.
 `tag`          | Yes      | The version of the `--repo` to install from. Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
-`module-name`  | No       | The name of a module to install. Can be any folder within the `modules` directory of `--repo`. You must specify exactly one of `--module-name` or `--binary-name`.
-`binary-name`  | No       | The name of a binary to install. Can be any file uploaded as a release asset in `--repo`.  You must specify exactly one of `--module-name` or `--binary-name`.
+`module-name`  | XOR      | The name of a module to install. Can be any folder within the `modules` directory of `--repo`. You must specify exactly one of `--module-name` or `--binary-name`.
+`binary-name`  | XOR      | The name of a binary to install. Can be any file uploaded as a release asset in `--repo`.  You must specify exactly one of `--module-name` or `--binary-name`.
 `module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module as a parameter. May be used multiple times. See the documentation for each module to find out what parameters it accepts.
 `help`         | No       | Show the help text and exit.
 
 #### Examples
+
+##### Example 1: Download and Install a Module with No Parameters
 
 Install the [ecs-scripts
 module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) from the [module-ecs
@@ -58,6 +108,8 @@ repo](https://github.com/gruntwork-io/module-ecs), version `0.0.1`:
 gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag '0.0.1'
 ```
 
+##### Example 2: Download and Install a Module with Parameters
+
 Install the [vault-ssh-helper
 module](https://github.com/gruntwork-io/script-modules/tree/master/modules/vault-ssh-helper) from the [script-modules
 repo](https://github.com/gruntwork-io/script-modules), passing two custom parameters to it:
@@ -65,6 +117,8 @@ repo](https://github.com/gruntwork-io/script-modules), passing two custom parame
 ```
 gruntwork-install --module-name 'vault-ssh-helper' --repo 'https://github.com/gruntwork-io/script-modules' --tag '0.0.3' --module-param 'install-dir=/opt/vault-ssh-helper' --module-param 'owner=ubuntu'
 ```
+
+##### Example 3: Download and Install a Binary 
 
 Install the `gruntkms` binary from the `v0.0.1` release of the [gruntkms
 repo](https://github.com/gruntwork-io/gruntkms):
@@ -76,6 +130,8 @@ gruntwork-install --binary-name 'gruntkms' --repo 'https://github.com/gruntwork-
 Note that the [v0.0.1 release of the gruntkms repo](https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.1) has
 multiple binaries (`gruntkms_linux_amd64`, `gruntkms_darwin_386`, etc): `gruntwork-install` automatically picks the
 right binary for your OS and copies it to `/usr/local/bin/gruntkms`.
+
+##### Example 4: Use `gruntwork-install` in a Packer template
 
 Finally, to put all the pieces together, here is an example of a Packer template that installs `gruntwork-install`
 and then uses it to install several modules:
@@ -110,24 +166,6 @@ and then uses it to install several modules:
 }
 ```
 
-## How Gruntwork modules work
-
-`gruntwork-install` does the following:
-
-1. Uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the module or binary from
-   the repo specified via the `--repo` option.
-1. If you used the `--module-name` parameter, it downloads the module from the `modules` folder of `--repo` and runs
-   the `install.sh` script of that module.
-1. If you used the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
-   and gives it execute permissions.
-
-Future versions of `gruntwork-install` may do more (e.g. verify checksums, manage dependencies), but for now, that's
-all there is to it.
-
-That means that to create an installable module, all you have to do is put it in the `modules` folder and include an
-`install.sh` script; to create an installable binary, you just publish it to a GitHub release with the name format
-`<NAME>_<OS>_<ARCH>`.
-
 ## Running tests
 
 The tests for this repo are defined in the `test` folder. They are designed to run in a Docker container so that you
@@ -141,7 +179,9 @@ To run the tests:
    the environment variable `GITHUB_OAUTH_TOKEN`.
 1. `./_ci/run-tests.sh`
 
-## Is it safe to pipe URLs into bash?
+## Security 
+
+### Is it safe to pipe URLs into bash?
 
 Are you worried that our install instructions tell you to pipe a URL into bash? Although this approach has seen some
 [backlash](https://news.ycombinator.com/item?id=6650987), we believe that the convenience of a one-line install

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ want to update a binary or script to add a new parameter, each team has to modif
 painful. 
 
 We believe we can do better by writing our scripts and binaries in a standardized way, and including a minimal tool that 
-streamlines the process of downloading and installing them. Indeed, our goal is to make installing Gruntwork Script 
-Modules as easy as installing a typical package using `apt-get`, `yum`, `npm`, or similar tools. And since we give you 
-100% of the source code, we want it to be clear exactly what happens when you install a Gruntwork Script Module.  
+streamlines the process of downloading and installing them. Also, installation should be streamlined no matter what 
+platform (Windows, MacOS, Linux) you're on. 
+
+Indeed, our goal is to make installing Gruntwork Script  Modules as easy as installing a typical package using `apt-get`, 
+`yum`, `npm`, or similar tools. We would have just used these existing tools, but none offer multi-platform compatibility.
+Finally, since we give you 100% of the source code, we want it to be clear exactly what happens when you install a 
+Gruntwork Script Module.  
 
 ### How `gruntwork-install` Works
 
@@ -101,7 +105,7 @@ Option           | Required | Description
 `--tag`          | Yes      | The version of the `--repo` to install from.<br>Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
 `--module-name`  | XOR      | The name of a module to install.<br>Can be any folder within the `modules` directory of `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
 `--binary-name`  | XOR      | The name of a binary to install.<br>Can be any file uploaded as a release asset in `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
-`--module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module<br>as a parameter. May be used multiple times.<br>See the documentation for each module to find out what parameters it accepts.
+`--module-param` | No       | A key-value pair of the format `key=value` you wish to pass to the module as a parameter.<br>May be used multiple times.<br>See the documentation for each module to find out what parameters it accepts.
 `--help`         | No       | Show the help text and exit.
 
 #### Examples

--- a/examples/packer-file-copy/files/foo/bar/test.txt
+++ b/examples/packer-file-copy/files/foo/bar/test.txt
@@ -1,0 +1,1 @@
+This file should be copied by the packer-file-copy module into /foo/bar/test.txt.

--- a/examples/packer-file-copy/packer-example.json
+++ b/examples/packer-file-copy/packer-example.json
@@ -1,0 +1,40 @@
+{
+  "variables": {
+    "aws_region": "us-east-1",
+    "github_auth_token": "{{env `GITHUB_OAUTH_TOKEN`}}",
+    "gruntwork_installer_version": "0.0.13",
+    "gruntwork_packer_file_copy_version": "v0.0.1"
+  },
+  "builders": [{
+    "ami_name": "gruntwork-cloudwatch-log-aggregation-example-ubuntu-{{isotime | clean_ami_name}}",
+    "ami_description": "An Ubuntu AMI that shows an example of using the packer-file-copy module to copy files into an AMI.",
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami": "ami-fce3c696",
+    "ssh_username": "ubuntu",
+    "name": "ubuntu-build"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": [
+      "echo 'Sleeping for 30 seconds to give the AMIs enough time to initialize (otherwise, packages may fail to install).'",
+      "sleep 30"
+    ]
+  },{
+    "type": "file",
+    "source": "{{template_dir}}/files",
+    "destination": "/tmp/packer-files"
+  },{
+    "type": "shell",
+    "inline": "curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version {{user `gruntwork_installer_version`}}"
+  },{
+    "type": "shell",
+    "inline": [
+      "gruntwork-install --module-name 'packer-file-copy' --repo 'https://github.com/gruntwork-io/package-util' --tag '{{user `gruntwork_packer_file_copy_version`}}'"
+    ],
+    "environment_vars": [
+      "GITHUB_OAUTH_TOKEN={{user `github_auth_token`}}"
+    ]
+  }]
+}

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# This script can be usedGruntwork Script Modules from https://github.com/gruntwork-io/script-modules using fetch
-# (https://github.com/gruntwork-io/fetch), and then runs it. The main motivation in writing it is to make installing
+# This script installs Gruntwork Script Modules. The main motivation in writing it is to make installing
 # Gruntwork Script Modules feel as easy as installing a package using apt-get, brew, or yum.
 #
 # Note that if the user specifies neither --tag nor --branch, the latest tag is downloaded.

--- a/modules/README.md
+++ b/modules/README.md
@@ -2,12 +2,4 @@
 
 This folder contains Gruntwork Script Modules that are commonly used and made freely available.
 
-### What's a Gruntwork Script Module?
-
-A Gruntwork Script Module is a package of one or more bash scripts and/or binaries maintained by Gruntwork that are meant to be 
-reusable in many different contexts. For example, we have Script Modules for installing a CloudWatch Logs agent, optimizing
-syslog settings, setting up automatic security updates, and more. 
-
-Our Script Modules are contained in the `modules/` folder of different GitHub repos since they often come with the 
-different [Infrastructure Packages](https://blog.gruntwork.io/gruntwork-infrastructure-packages-7434dc77d0b1#.6bwor6wxc) 
-we sell. 
+See [Gruntwork Modules](../add-packer-file-copy#gruntwork-modules) to learn more about what a Gruntwork Script Module is.

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,13 @@
+# Freely Available Gruntwork Script Modules
+
+This folder contains Gruntwork Script Modules that are commonly used and made freely available.
+
+### What's a Gruntwork Script Module?
+
+A Gruntwork Script Module is a package of one or more bash scripts and/or binaries maintained by Gruntwork that are meant to be 
+reusable in many different contexts. For example, we have Script Modules for installing a CloudWatch Logs agent, optimizing
+syslog settings, setting up automatic security updates, and more. 
+
+Our Script Modules are contained in the `modules/` folder of different GitHub repos since they often come with the 
+different [Infrastructure Packages](https://blog.gruntwork.io/gruntwork-infrastructure-packages-7434dc77d0b1#.6bwor6wxc) 
+we sell. 

--- a/modules/packer-file-copy/README.md
+++ b/modules/packer-file-copy/README.md
@@ -1,0 +1,30 @@
+# Packer File Copy
+
+This module is intended to be used in a [Packer template](https://www.packer.io/) to move all files that template
+copies into `/tmp/packer-files/XXX/YYY` into `/XXX/YYY`. For example, if you used the `file` provisioner to upload a
+file to `/tmp/packer-files/foo/bar`, it will be moved to `/foo/bar`.
+
+Why not just upload these files directly with Packer? Because:
+
+1. If the destination folder doesn't exist, the `file` provisioner won't create it. Instead, you just get an error.
+1. The `file` provisioner may not have permissions to write to certain folders (e.g. `/opt/my-app`) and it can't use
+   `sudo`.
+
+As a result, using the `file` provisioner is often a multi-step process where you first copy the files to a temporary
+folder, then run scripts to create the real destination folder, move your files there, and update permissions. This
+packer-file-copy module automates all these steps.
+
+For an example of this module in action, see [examples/packer-file-copy](../../examples/packer-file-copy/).
+
+IMPORTANT: The packer file provisioner should look like the following:
+
+```json
+{
+    "type": "file",
+    "source": "{{template_dir}}/files",
+    "destination": "/tmp/packer-files"
+}
+```
+
+Note how both the source and destination have no trailing slash. Adding a trailing slash will mean Packer will upload
+files differently than intended.

--- a/modules/packer-file-copy/install-scripts/copy-packer-files.sh
+++ b/modules/packer-file-copy/install-scripts/copy-packer-files.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Copy all files located in the $DEFAULT_PACKER_FILES_PATH to their corresponding location on the file systemm. For 
+# example, copy /tmp/packer-files/foo/bar.txt to /foo/bar.txt.
+#
+# Detailed Example:
+# $ DEFAULT_PACKER_FILES_PATH="/tmp/packer-files"
+# $ tree /tmp/packer-files:
+# .
+# ├── etc
+# │   └── foo.config
+# └── opt
+#     └── bar.sh
+#
+# $ ./copy-packer-files.sh
+# $ ls /etc/
+# foo.config
+# $ ls /opt/
+# bar.sh
+
+set -e
+
+# Declare an array of paths to which Packer uploaded files
+readonly DEFAULT_PACKER_FILES_PATH="/tmp/packer-files"
+
+function copy_packer_files {
+  local readonly file_upload_paths=("$DEFAULT_PACKER_FILES_PATH")
+  local readonly script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  # For each file upload path, if there are any files there, relocate the files to their proper directories
+  for upload_path in "${file_upload_paths[@]}"; do
+      if [[ -e "$upload_path" ]]; then
+          # Get the length of the string that $upload_path resolves to
+          local readonly upload_path_length=${#upload_path}
+          local file=""
+
+          for file in $(find "$upload_path" -type f); do
+              local readonly absolute_filename="${file:$upload_path_length}";
+              echo "The packer-file-copy module is copying $file to $absolute_filename"
+              sudo mkdir -p $(dirname "$absolute_filename");
+              sudo mv "$file" "$absolute_filename";
+          done
+      fi
+  done
+
+  # Write README in case a future user is confused about /tmp/packer-files
+  if [[ -e "$DEFAULT_PACKER_FILES_PATH" ]]; then
+    cp "$script_path/../README.md" "$DEFAULT_PACKER_FILES_PATH"
+  fi
+}
+
+copy_packer_files

--- a/modules/packer-file-copy/install.sh
+++ b/modules/packer-file-copy/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Script used by gruntwork-install to install the packer-file-copy module.
+#
+
+set -e
+
+# Locate the directory in which this script is located
+readonly script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Execute the install script
+chmod u+x "${script_path}/install-scripts/copy-packer-files.sh"
+eval "${script_path}/install-scripts/copy-packer-files.sh $@"


### PR DESCRIPTION
This PR:

1. Adds the `packer-file-copy` Script Module to this repo.
2. Rewrites the top-level README to reflect our now more clear understanding of the role of Gruntwork Script Modules.

I'd also like to propose using the term "Gruntwork Script Module" as a first-class term. At some point, we may further clarify that in addition to "Script Modules" we have other types of modules. For example, the module used to generate a TLS cert for Vault isn't a Script Module, but maybe an "Execution Module".

@brikis98 For now, let me know your thoughts on what's updated in this PR.