### PR TITLE
Fix how module-param args are handled

### DIFF
--- a/gruntwork-install
+++ b/gruntwork-install
@@ -186,9 +186,11 @@ function run_module {
   local readonly download_dir="$2"
   shift 2
   local readonly module_params=($@)
+  local readonly install_script_path="${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME}"
 
-  chmod -R u+x "${download_dir}/${module_name}"
-  eval "${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME} ${module_params[@]}"
+  echo "Executing $install_script_path"
+  chmod u+x "$install_script_path"
+  eval "$install_script_path ${module_params[@]}"
 }
 
 function install_script_module {

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -185,10 +185,10 @@ function run_module {
   local readonly module_name="$1"
   local readonly download_dir="$2"
   shift 2
-  local readonly module_params="$@"
+  local readonly module_params=($@)
 
   chmod -R u+x "${download_dir}/${module_name}"
-  ${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME} $module_params
+  eval "${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME} ${module_params[@]}"
 }
 
 function install_script_module {

--- a/modules/dummy-module/README.md
+++ b/modules/dummy-module/README.md
@@ -1,0 +1,3 @@
+# Dummy module
+
+This module is used solely for running automated tests against the Gruntwork Installer. 

--- a/modules/dummy-module/install.sh
+++ b/modules/dummy-module/install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# A dirt simple install script that expects a single argument, --file-to-cat, that it runs cat on. This is used to
+# test that the --module-param args in gruntwork-install work correctly.
+
+set -e
+
+function assert_not_empty {
+  local readonly arg_name="$1"
+  local readonly arg_value="$2"
+
+  if [[ -z "$arg_value" ]]; then
+    echo "ERROR: The value for '$arg_name' cannot be empty"
+    exit 1
+  fi
+}
+
+function install {
+  local file_to_cat
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+
+    case "$key" in
+      --file-to-cat)
+        file_to_cat="$2"
+        shift
+        ;;
+      *)
+        echo "Unrecognized argument: $key"
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  assert_not_empty "--file-to-cat" "$file_to_cat"
+  cat "$file_to_cat"
+}
+
+install "$@"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -5,6 +5,7 @@
 set -e
 
 readonly LOCAL_INSTALL_URL="file:///src/gruntwork-install"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Using local copy of bootstrap installer to install local copy of gruntwork-install"
 ./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
@@ -19,7 +20,7 @@ echo "Checking that the ecs-scripts installed correctly"
 configure-ecs-instance --help
 
 echo "Using gruntwork-install to install a module from the gruntwork-install repo and passing args to it via --module-param"
-gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --branch "fix-args" --module-param "file-to-cat=README.md"
+gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --branch "fix-args" --module-param "file-to-cat=$SCRIPT_DIR/integration-test.sh"
 
 echo "Using gruntwork-install to install a binary from the gruntkms repo"
 gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-io/gruntkms" --tag "v0.0.1"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -13,7 +13,7 @@ echo "Using gruntwork-install to install a module from the module-ecs repo"
 gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1"
 
 echo "Using gruntwork-install to install a module from the module-ecs repo with --download-dir option"
-gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1" --download-dir "~/tmp"
+gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1" --download-dir ~/tmp
 
 echo "Checking that the ecs-scripts installed correctly"
 configure-ecs-instance --help

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -9,12 +9,6 @@ readonly LOCAL_INSTALL_URL="file:///src/gruntwork-install"
 echo "Using local copy of bootstrap installer to install local copy of gruntwork-install"
 ./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
 
-echo "Using gruntwork-install to install a few modules from script-modules"
-gruntwork-install --module-name "vault-ssh-helper" --repo "https://github.com/gruntwork-io/script-modules" --tag "~>0.0.21"
-
-echo "Checking that the vault-ssh-helper installed correctly"
-/etc/user-data/vault-ssh-helper/download-ca-cert.sh --help
-
 echo "Using gruntwork-install to install a module from the module-ecs repo"
 gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1"
 
@@ -23,6 +17,9 @@ gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwo
 
 echo "Checking that the ecs-scripts installed correctly"
 configure-ecs-instance --help
+
+echo "Using gruntwork-install to install a module from the gruntwork-install repo and passing args to it via --module-param"
+gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --branch "fix-args" --module-param "file-to-cat=README.md"
 
 echo "Using gruntwork-install to install a binary from the gruntkms repo"
 gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-io/gruntkms" --tag "v0.0.1"


### PR DESCRIPTION
This PR fixes a bug with the `--module-param` args of `gruntwork-install`. We wrap those args in single quotes to handle possible spaces, but in order for that to work correctly, we need to `eval` the args. 

Along the way, I had to do a bit of yak shaving to fix other issues in the tests. Not sure how these passed before?