### PR TITLE
Fix issue with quotes around module params.

### DIFF
--- a/gruntwork-install
+++ b/gruntwork-install
@@ -178,7 +178,7 @@ function convert_module_params_format {
   local readonly key_value_pair="$1"
   local readonly key="${key_value_pair%%=*}"
   local readonly val="${key_value_pair#*=}"
-  echo "--${key} '${val}'"
+  echo "--${key} \"${val}\""
 }
 
 function run_module {
@@ -188,7 +188,7 @@ function run_module {
   local readonly module_params=($@)
   local readonly install_script_path="${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME}"
 
-  echo "Executing $install_script_path"
+  echo "Executing $install_script_path ${module_params[@]}"
   chmod u+x "$install_script_path"
   eval "$install_script_path ${module_params[@]}"
 }


### PR DESCRIPTION
Previously, a param was rendering as the literal " 'literal-val' " with single quotes, which was causing the script that was receiving this value to fail. Using double quotes removes the issue.