### PR TITLE
Add support for 686

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -123,6 +123,8 @@ function get_os_arch_gox_format {
     echo "amd64"
   elif $(string_contains "$arch" "386"); then
     echo "386"
+  elif $(string_contains "$arch" "686"); then
+    echo "386" # Not a typo; 686 is also 32-bit and should work with 386 binaries
   elif $(string_contains "$arch" "arm"); then
     echo "arm"
   fi


### PR DESCRIPTION
One of our customers is on a 32-bit system that identifies its architecture as 686. This should work with 386 binaries, so update the bootstrap script to support that.