### PR TITLE
Update use of fetch to resolve-symlinks when included in modules.

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -21,7 +21,7 @@ set -e
 readonly BIN_DIR="/usr/local/bin"
 readonly USER_DATA_DIR="/etc/user-data"
 
-readonly DEFAULT_FETCH_VERSION="v0.2.0"
+readonly DEFAULT_FETCH_VERSION="v0.2.1"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -122,7 +122,7 @@ function fetch_script_module {
   # Note that fetch can safely handle blank arguments for --tag or --branch
   # If both --tag and --branch are specified, --branch will be used
   log_info "Downloading module $module_name from $repo"
-  fetch --repo="$repo" --tag="$tag" --branch="$branch" --source-path="/modules/$module_name" "$download_dir/$module_name"
+  fetch --repo="$repo" --tag="$tag" --branch="$branch" --source-path="/modules/$module_name" --resolve-symlinks "$download_dir/$module_name"
 }
 
 # Download a binary asset from a GitHub release using fetch (https://github.com/gruntwork-io/fetch)


### PR DESCRIPTION
Some Gruntwork modules need to reference a common folder in a repo such as a "bash commons", but fetch installs only a module's directory, not the whole repo, so what to do?

This change incorporates the new `--resolve-symlinks feature` implemented in https://github.com/gruntwork-io/fetch/pull/40. This way, a module can include a symlink to a common folder, and when the module is installed, each symlink will be replaced with the contents of its targets.

**Important:** Make sure not to merge this until https://github.com/gruntwork-io/fetch/pull/40 has been merged. Note that the build will fail until that PR is merged.