### PR TITLE
Allow public repo access

### DIFF
--- a/gruntwork-install
+++ b/gruntwork-install
@@ -220,6 +220,15 @@ function convert_module_params_format {
   echo "--${key} \"${val}\""
 }
 
+
+# Check if the repo is anonymously accessible. This indicates that the repo is public, and will skip checks for the
+# token.
+function repo_is_public {
+  local readonly repo_url="$1"
+
+  curl --silent --fail "$repo_url" > /dev/null
+}
+
 function run_module {
   local readonly module_name="$1"
   local readonly download_dir="$2"
@@ -298,9 +307,13 @@ function install_script_module {
     shift
   done
 
-  assert_is_installed fetch
-  assert_env_var_not_empty "GITHUB_OAUTH_TOKEN"
   assert_not_empty "--repo" "$repo"
+  assert_is_installed fetch
+
+  if ! repo_is_public "$repo"; then
+    log_info "Repository is not public. GITHUB_OAUTH_TOKEN environment variable is required."
+    assert_env_var_not_empty "GITHUB_OAUTH_TOKEN"
+  fi
 
   if [[ ( -z "$module_name" && -z "$binary_name" ) || ( ! -z "$module_name" && ! -z "$binary_name" ) ]]; then
     log_error "You must specify exactly one of --module-name or --binary-name."

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -27,3 +27,18 @@ gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-
 
 echo "Checking that gruntkms installed correctly"
 gruntkms --help
+
+echo "Unsetting GITHUB_OAUTH_TOKEN to test installing from public repo (terragrunt)"
+unset GITHUB_OAUTH_TOKEN
+
+echo "Verifying private repo access is denied"
+if gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-io/gruntkms" --tag "v0.0.1" ; then
+  echo "ERROR: was able to access private repo"
+  exit 1
+fi
+
+echo "Verifying public repo access is allowed"
+gruntwork-install --repo 'https://github.com/gruntwork-io/terragrunt' --binary-name terragrunt --tag '~>v0.18.4'
+
+echo "Checking that terragrunt installed correctly"
+terragrunt --help


### PR DESCRIPTION
Right now `gruntwork-install` enforces the condition that `GITHUB_OAUTH_TOKEN` is set, but this does not need to be set for public repos (e.g `terragrunt`, `terratest`, and soon `kubergrunt`). This PR adds a simple check to see if the repo can be accessed anonymously (does not 404), and if so, ignore the check.