### PR TITLE
Preserve whitespace in parameter values and treat as whole args

### DIFF
--- a/gruntwork-install
+++ b/gruntwork-install
@@ -209,21 +209,6 @@ function determine_binary_name {
   echo "${binary_name}_${os_name}_${os_arch}"
 }
 
-# Take in a key-value pair of the format key=value and convert it to the format that Gruntwork bash scripts expect:
-# --key value
-function convert_module_params_format {
-  local -r key_value_pair="$1"
-  local -r key="${key_value_pair%%=*}"
-  local -r val="${key_value_pair#*=}"
-  local -ra params=( "--${key}" "${val}")
-  
-  # Print the value out as something that can be evaled back into an array
-  # Note: this prints something like '([0]="key_name" [1]="value1 value2 value3")'
-  local -r ret="$(declare -p params)"
-  echo "${ret#*=}"
-}
-
-
 # Check if the repo is anonymously accessible. This indicates that the repo is public, and will skip checks for the
 # token.
 function repo_is_public {
@@ -288,9 +273,9 @@ function install_script_module {
         shift
         ;;
       --module-param)
-        local -a param=()
-        eval "local -a param=$(convert_module_params_format "$2")"
-        module_params+=("${param[@]}")
+        local module_param_key="${2%%=*}"
+        local module_param_val="${2#*=}"
+        module_params+=( "--$module_param_key" "$module_param_val" )
         shift
         ;;
       --download-dir)

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -50,26 +50,27 @@ function print_usage {
 
 function log {
   local -r level="$1"
-  local -r message="$2"
+  shift
+  local -ra message=("$@")
   local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   local -r scriptname="$(basename "$0")"
 
-  >&2 echo -e "${timestamp} [${level}] [$scriptname] ${message}"
+  >&2 echo -e "${timestamp} [${level}] [$scriptname] ${message[@]}"
 }
 
 function log_info {
-  local -r message="$1"
-  log "INFO" "$message"
+  local -ra message=("$@")
+  log "INFO" "${message[@]}"
 }
 
 function log_warn {
-  local -r message="$1"
-  log "WARN" "$message"
+  local -ra message=("$@")
+  log "WARN" "${message[@]}"
 }
 
 function log_error {
-  local -r message="$1"
-  log "ERROR" "$message"
+  local -ra message=("$@")
+  log "ERROR" "${message[@]}"
 }
 
 # Assert that a given binary is installed on this box
@@ -214,7 +215,8 @@ function convert_module_params_format {
   local -r key_value_pair="$1"
   local -r key="${key_value_pair%%=*}"
   local -r val="${key_value_pair#*=}"
-  echo "--${key} \"${val}\""
+  local -ra params=( "--${key}" "${val}")
+  printf '%s\n' "${params[@]}"
 }
 
 
@@ -230,12 +232,12 @@ function run_module {
   local -r module_name="$1"
   local -r download_dir="$2"
   shift 2
-  local -ra module_params=($@)
+  local -ra module_params=("$@")
   local -r install_script_path="${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME}"
 
   log_info "Executing $install_script_path ${module_params[@]}"
   chmod u+x "$install_script_path"
-  eval "$install_script_path ${module_params[@]}"
+  "$install_script_path" "${module_params[@]}"
 }
 
 function install_script_module {
@@ -282,8 +284,9 @@ function install_script_module {
         shift
         ;;
       --module-param)
-        local -r param=$(convert_module_params_format "$2")
-        module_params+=("$param")
+        local -a param=()
+        mapfile -t param <<<"$(convert_module_params_format "$2")"
+        module_params+=("${param[@]}")
         shift
         ;;
       --download-dir)

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -216,7 +216,11 @@ function convert_module_params_format {
   local -r key="${key_value_pair%%=*}"
   local -r val="${key_value_pair#*=}"
   local -ra params=( "--${key}" "${val}")
-  printf '%s\n' "${params[@]}"
+  
+  # Print the value out as something that can be evaled back into an array
+  # Note: this prints something like '([0]="key_name" [1]="value1 value2 value3")'
+  local -r ret="$(declare -p params)"
+  echo "${ret#*=}"
 }
 
 
@@ -285,7 +289,7 @@ function install_script_module {
         ;;
       --module-param)
         local -a param=()
-        mapfile -t param <<<"$(convert_module_params_format "$2")"
+        eval "local -a param=$(convert_module_params_format "$2")"
         module_params+=("${param[@]}")
         shift
         ;;

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -20,7 +20,10 @@ echo "Checking that the ecs-scripts installed correctly"
 configure-ecs-instance --help
 
 echo "Using gruntwork-install to install a module from the gruntwork-install repo and passing args to it via --module-param"
-gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --tag "v0.0.17" --module-param "file-to-cat=$SCRIPT_DIR/integration-test.sh"
+gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --tag "v0.0.25" --module-param "file-to-cat=$SCRIPT_DIR/integration-test.sh"
+
+echo "Using gruntwork-install to install a test module from the gruntwork-install repo and test that it's args are maintained via --module-param"
+gruntwork-install --module-name "args-test" --repo "https://github.com/gruntwork-io/gruntwork-installer" --tag "v0.0.25" --module-param 'test-args=1 2 3 *'
 
 echo "Using gruntwork-install to install a binary from the gruntkms repo"
 gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-io/gruntkms" --tag "v0.0.1"


### PR DESCRIPTION
The installer supports passing parameters to the module installers. However, in several places it's munging the whitespace and splitting the arguments into multiple args.

This change seeks to maintain args as single, whole args and not split on whitespace.