### PR TITLE
Support a no-sudo install (limited to binaries)

### DIFF
--- a/_ci/run-tests.sh
+++ b/_ci/run-tests.sh
@@ -9,9 +9,11 @@ docker build -t gruntwork/gruntwork-installer-ubuntu test/ubuntu
 docker build -t gruntwork/gruntwork-installer-ubuntu18 test/ubuntu18
 docker build -t gruntwork/gruntwork-installer-amazonlinux test/amazonlinux
 docker build -t gruntwork/gruntwork-installer-centos test/centos
+docker build -t gruntwork/gruntwork-installer-no-sudo-ubuntu test/no_sudo
 
 echo "Running integration tests using docker-compose"
 docker-compose -f test/ubuntu/docker-compose.yml run installer /test/integration-test.sh
 docker-compose -f test/ubuntu18/docker-compose.yml run installer /test/integration-test.sh
 docker-compose -f test/amazonlinux/docker-compose.yml run installer /test/integration-test.sh
 docker-compose -f test/centos/docker-compose.yml run installer /test/integration-test.sh
+docker-compose -f test/no_sudo/docker-compose.yml run installer /test/no-sudo-test.sh

--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -62,6 +62,7 @@ function download_url_to_file {
   local -r url="$1"
   local -r file="$2"
   local -r tmp_path=$(mktemp "/tmp/gruntwork-bootstrap-download-XXXXXX")
+  local -r no_sudo="$3"
 
   echo "Downloading $url to $tmp_path"
   if command_exists "curl"; then
@@ -69,7 +70,11 @@ function download_url_to_file {
     assert_successful_status_code "$status_code" "$url"
 
     echo "Moving $tmp_path to $file"
-    sudo mv -f "$tmp_path" "$file"
+    if [[ "$no_sudo" == "true" ]]; then
+      mv -f "$tmp_path" "$file"
+    else
+      sudo mv -f "$tmp_path" "$file"
+    fi
   else
     echo "ERROR: curl is not installed. Cannot download $url."
     exit 1
@@ -136,7 +141,7 @@ function download_and_install {
   local -r install_path="$2"
   local -r no_sudo="$3"
 
-  download_url_to_file "$url" "$install_path"
+  download_url_to_file "$url" "$install_path" "$no_sudo"
 
   if [[ "$no_sudo" == "true" ]]; then
     chmod 0755 "$install_path"

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -75,6 +75,17 @@ function log_error {
   log "ERROR" "${message[@]}"
 }
 
+function maybe_sudo {
+  local -r no_sudo="$1"
+  shift
+
+  if [[ "$no_sudo" == "true" ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
 # Assert that a given binary is installed on this box
 function assert_is_installed {
   local -r name="$1"
@@ -154,13 +165,8 @@ function fetch_binary {
   fi
 
   log_info "Moving $full_download_path to $full_dest_path and setting execute permissions"
-  if [[ "$no_sudo" == "true" ]]; then
-    mv "$full_download_path" "$full_dest_path"
-    chmod u+x "$full_dest_path"
-  else
-    sudo mv "$full_download_path" "$full_dest_path"
-    sudo chmod u+x "$full_dest_path"
-  fi
+  maybe_sudo "$no_sudo" mv "$full_download_path" "$full_dest_path"
+  maybe_sudo "$no_sudo" chmod u+x "$full_dest_path"
 }
 
 # Validate that at least one file was downloaded from the module; otherwise throw an error.

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -12,7 +12,7 @@ readonly MODULES_DIR="modules"
 readonly MODULE_INSTALL_FILE_NAME="install.sh"
 
 readonly DEFAULT_MODULES_DOWNLOAD_DIR="/tmp/gruntwork-script-modules"
-readonly BIN_DIR="/usr/local/bin"
+readonly DEFAULT_BIN_DIR="/usr/local/bin"
 
 function print_usage {
   echo
@@ -36,6 +36,8 @@ function print_usage {
   echo
   echo -e "  --module-param\tA key-value pair of the format key=value you wish to pass to the module as a parameter. May be used multiple times."
   echo -e "  --download-dir\tThe directory to which the module will be downloaded and from which it will be installed. Default: $DEFAULT_MODULES_DOWNLOAD_DIR"
+  echo -e "  --binary-install-dir\tThe directory to which the binary will be installed. Only applies to binaries (not modules). Default: $DEFAULT_BIN_DIR"
+  echo -e "  --no-sudo\t\tWhen true, don't use sudo to install the binary into the install directory. Only applies to binaries (not modules). Default: false"
   echo -e "  --branch\t\tDownload the latest commit from this branch in --repo. This is an alternative to --tag, used only for testing."
   echo -e "  --help\t\tShow this help text and exit."
 
@@ -130,12 +132,14 @@ function fetch_binary {
   local -r repo="$4"
   local -r sha256_checksum="$5"
   local -r sha512_checksum="$6"
+  local -r binary_install_dir="$7"
+  local -r no_sudo="$8"
 
   local binary_name_full=""
   binary_name_full=$(determine_binary_name "$binary_name")
 
   local -r full_download_path="$download_dir/$binary_name_full"
-  local -r full_dest_path="$BIN_DIR/$binary_name"
+  local -r full_dest_path="$binary_install_dir/$binary_name"
 
   # We want to make sure that all folders down to $download_path exist, but that $download_path/$binary_name_full does not
   mkdir -p "$download_dir"
@@ -150,8 +154,13 @@ function fetch_binary {
   fi
 
   log_info "Moving $full_download_path to $full_dest_path and setting execute permissions"
-  sudo mv "$full_download_path" "$full_dest_path"
-  sudo chmod u+x "$full_dest_path"
+  if [[ "$no_sudo" == "true" ]]; then
+    mv "$full_download_path" "$full_dest_path"
+    chmod u+x "$full_dest_path"
+  else
+    sudo mv "$full_download_path" "$full_dest_path"
+    sudo chmod u+x "$full_dest_path"
+  fi
 }
 
 # Validate that at least one file was downloaded from the module; otherwise throw an error.
@@ -236,9 +245,11 @@ function install_script_module {
   local binary_name=""
   local binary_sha256_checksum=""
   local binary_sha512_checksum=""
+  local binary_install_dir="$DEFAULT_BIN_DIR"
   local repo=""
   local download_dir="$DEFAULT_MODULES_DOWNLOAD_DIR"
   local module_params=()
+  local no_sudo="false"
 
   while [[ $# -gt 0 ]]; do
     local key="$1"
@@ -280,6 +291,14 @@ function install_script_module {
         ;;
       --download-dir)
         download_dir="$2"
+        shift
+        ;;
+      --binary-install-dir)
+        binary_install_dir="$2"
+        shift
+        ;;
+      --no-sudo)
+        no_sudo="$2"
         shift
         ;;
       --help)
@@ -326,7 +345,7 @@ function install_script_module {
     run_module "$module_name" "$download_dir" "${module_params[@]}"
   else
     log_info "Installing $binary_name..."
-    fetch_binary "$binary_name" "$tag" "$download_dir" "$repo" "$binary_sha256_checksum" "$binary_sha512_checksum"
+    fetch_binary "$binary_name" "$tag" "$download_dir" "$repo" "$binary_sha256_checksum" "$binary_sha512_checksum" "$binary_install_dir" "$no_sudo"
   fi
 
   log_info "Success!"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -31,17 +31,6 @@ gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-
 echo "Checking that gruntkms installed correctly"
 gruntkms --help
 
-echo "Using gruntwork-install to install a binary from the gruntkms repo into a different folder without using sudo"
-gruntwork-install \
-  --binary-name "gruntkms" \
-  --repo "https://github.com/gruntwork-io/gruntkms" \
-  --tag "v0.0.1" \
-  --binary-install-dir "$HOME" \
-  --no-sudo "true"
-
-echo "Checking that gruntkms installed correctly into home dir"
-"$HOME/gruntkms" --help
-
 echo "Unsetting GITHUB_OAUTH_TOKEN to test installing from public repo (terragrunt)"
 unset GITHUB_OAUTH_TOKEN
 

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -31,6 +31,17 @@ gruntwork-install --binary-name "gruntkms" --repo "https://github.com/gruntwork-
 echo "Checking that gruntkms installed correctly"
 gruntkms --help
 
+echo "Using gruntwork-install to install a binary from the gruntkms repo into a different folder without using sudo"
+gruntwork-install \
+  --binary-name "gruntkms" \
+  --repo "https://github.com/gruntwork-io/gruntkms" \
+  --tag "v0.0.1" \
+  --binary-install-dir "$HOME" \
+  --no-sudo
+
+echo "Checking that gruntkms installed correctly into home dir"
+"$HOME/gruntkms" --help
+
 echo "Unsetting GITHUB_OAUTH_TOKEN to test installing from public repo (terragrunt)"
 unset GITHUB_OAUTH_TOKEN
 

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -37,7 +37,7 @@ gruntwork-install \
   --repo "https://github.com/gruntwork-io/gruntkms" \
   --tag "v0.0.1" \
   --binary-install-dir "$HOME" \
-  --no-sudo
+  --no-sudo "true"
 
 echo "Checking that gruntkms installed correctly into home dir"
 "$HOME/gruntkms" --help

--- a/test/no-sudo-test.sh
+++ b/test/no-sudo-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Some basic automated tests for gruntwork-installer
+
+set -e
+
+readonly LOCAL_INSTALL_URL="file:///src/gruntwork-install"
+
+echo "Using local copy of bootstrap installer to install local copy of gruntwork-install"
+./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install" --no-sudo "true"
+
+echo "Using gruntwork-install to install a binary from the gruntkms repo into a different folder without using sudo"
+gruntwork-install \
+  --binary-name "gruntkms" \
+  --repo "https://github.com/gruntwork-io/gruntkms" \
+  --tag "v0.0.1" \
+  --binary-install-dir "$HOME" \
+  --no-sudo "true"
+
+echo "Checking that gruntkms installed correctly into home dir"
+"$HOME/gruntkms" --help

--- a/test/no_sudo/Dockerfile
+++ b/test/no_sudo/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+MAINTAINER Gruntwork <info@gruntwork.io>
+
+RUN apt-get update
+RUN apt-get install -y curl
+
+COPY . /test
+
+CMD ["echo", "This container is used for testing. Consider running one of the test scripts under the /test folder."]

--- a/test/no_sudo/docker-compose.yml
+++ b/test/no_sudo/docker-compose.yml
@@ -1,0 +1,10 @@
+installer:
+  image: gruntwork/gruntwork-installer-no-sudo-ubuntu
+  volumes:
+    # Mount the scripts in the root directory under /src
+    - ../../:/src
+    # Mount the test code in this directory under /test
+    - ../:/test
+  environment:
+    # Forward the GITHUB_OAUTH_TOKEN as an environment variable from the user's environment
+    - GITHUB_OAUTH_TOKEN


### PR DESCRIPTION
This PR addresses https://github.com/gruntwork-io/gruntwork-installer/issues/48

Specifically, both the bootstrap script and `gruntwork-install` now support an argument `--no-sudo` to allow installing binaries without the use of `sudo`.