### PR TITLE
Expose tag value as env var for module install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Once that environment variable is set, you can run `gruntwork-install` with the 
 Option                      | Required | Description
 --------------------------- | -------- | ------------
 `--repo`                    | Yes      | The GitHub repo to install from.
-`--tag`                     | Yes      | The version of the `--repo` to install from.<br>Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions).
+`--tag`                     | Yes      | The version of the `--repo` to install from.<br>Follows the syntax described at [Tag Constraint Expressions](https://github.com/gruntwork-io/fetch#tag-constraint-expressions). This value is exposed to module install scripts as GRUNTWORK_INSTALL_TAG.
 `--module-name`             | XOR      | The name of a module to install.<br>Can be any folder within the `modules` directory of `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
 `--binary-name`             | XOR      | The name of a binary to install.<br>Can be any file uploaded as a release asset in `--repo`.<br>You must specify exactly one of `--module-name` or `--binary-name`.
 `--binary-sha256-checksum`  | No       | The SHA256 checksum of the binary specified by `--binary-name`. Should be exactly 64 characters..

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -235,9 +235,13 @@ function repo_is_public {
 function run_module {
   local -r module_name="$1"
   local -r download_dir="$2"
-  shift 2
+  local -r tag="$3"
+  shift 3
   local -ra module_params=("$@")
   local -r install_script_path="${download_dir}/${module_name}/${MODULE_INSTALL_FILE_NAME}"
+
+  log_info "Setting GRUNTWORK_INSTALL_TAG to $tag"
+  export GRUNTWORK_INSTALL_TAG="$tag"
 
   log_info "Executing $install_script_path ${module_params[*]}"
   chmod u+x "$install_script_path"
@@ -348,7 +352,7 @@ function install_script_module {
     log_info "Installing from $module_name..."
     fetch_script_module "$module_name" "$tag" "$branch" "$download_dir" "$repo"
     validate_module "$module_name" "$download_dir" "$tag" "$branch" "$repo"
-    run_module "$module_name" "$download_dir" "${module_params[@]}"
+    run_module "$module_name" "$download_dir" "$tag" "${module_params[@]}"
   else
     log_info "Installing $binary_name..."
     fetch_binary "$binary_name" "$tag" "$download_dir" "$repo" "$binary_sha256_checksum" "$binary_sha512_checksum" "$binary_install_dir" "$no_sudo"


### PR DESCRIPTION
(NOTE: This is related to [this discussion](https://github.com/gruntwork-io/aws-service-catalog/pull/165#discussion_r481421956).)

In some cases, such as the situation linked above, we may wish to use the value of the `--tag` as a reference within an install script. This PR sets an env var to the tag so that the install script can use to avoid these chicken & egg scenarios.