### PR TITLE
First pass at enabling HTTP retries across the installer scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Option                      | Required | Description
 `--module-param`            | No       | A key-value pair of the format `key=value` you wish to pass to the module as a parameter. May be used multiple times. <br>Note: a `--` will automatically be appended to the `key` when your module is invoked<br>See the documentation for each module to find out what parameters it accepts.
 `--download-dir`            | No       | The directory to which the module will be downloaded and from which it will be installed.
 `--branch      `            | No       | Download the latest commit from this branch in --repo. This is an alternative to --tag,<br>and is used only for testing. This value is exposed to module install scripts as GRUNTWORK_INSTALL_BRANCH.
+`--enable-retries`          | No       | Attempt to retry downloads in the case of temporary errors. This applies to invocations of curl, fetch, etc.
 `--help`                    | No       | Show the help text and exit.
 
 #### Examples

--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -82,7 +82,7 @@ function download_url_to_file {
 
   echo "Downloading $url to $tmp_path"
   if command_exists "curl"; then
-    local -r status_code=$(curl --retry=$retry_number --retry-connrefused -L -s -w '%{http_code}' -o "$tmp_path" "$url")
+    local -r status_code=$(curl --retry $retry_number --retry-connrefused -L -s -w '%{http_code}' -o "$tmp_path" "$url")
     assert_successful_status_code "$status_code" "$url"
 
     echo "Moving $tmp_path to $file"
@@ -154,7 +154,9 @@ function download_and_install {
   local -r no_sudo="$3"
   local -r retry_number="$4"
 
-  download_url_to_file "$url" "$install_path" "$no_sudo"
+  echo "RT", $retry_number
+
+  download_url_to_file "$url" "$install_path" "$no_sudo" "$retry_number"
   maybe_sudo "$no_sudo" chmod 0755 "$install_path"
 }
 
@@ -174,7 +176,7 @@ function install_fetch {
 
   echo "Installing fetch version $version to $install_path"
   local -r url="${FETCH_DOWNLOAD_URL_BASE}/${version}/fetch_${os}_${os_arch}"
-  download_and_install "$url" "$install_path" "$no_sudo"
+  download_and_install "$url" "$install_path" "$no_sudo" "$retry_number"
 }
 
 function install_gruntwork_installer {
@@ -185,7 +187,7 @@ function install_gruntwork_installer {
   local -r retry_number="$5"
 
   echo "Installing $GRUNTWORK_INSTALLER_SCRIPT_NAME version $version to $install_path"
-  download_and_install "$download_url" "$install_path" "$no_sudo"
+  download_and_install "$download_url" "$install_path" "$no_sudo" "$retry_number"
 }
 
 function assert_not_empty {
@@ -255,8 +257,7 @@ function bootstrap {
         shift
         ;;
       --enable-retries)
-        retry_number=10
-        shift
+        retry_number="$ENABLED_CURL_RETRY_NUMBER"
         ;;
       --help)
         print_usage

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -42,7 +42,7 @@ function print_usage {
   echo -e "  --binary-install-dir\tThe directory to which the binary will be installed. Only applies to binaries (not modules). Default: $DEFAULT_BIN_DIR"
   echo -e "  --no-sudo\t\tWhen true, don't use sudo to install the binary into the install directory. Only applies to binaries (not modules). Default: false"
   echo -e "  --branch\t\tDownload the latest commit from this branch in --repo. This is an alternative to --tag, used only for testing."
-  echo -e "  --enable-retries\t\tEnable retry logic in all downloads, where possible."
+  echo -e "  --enable-retries\tEnable retry logic in all downloads, where possible."
   echo -e "  --help\t\tShow this help text and exit."
 
   echo
@@ -324,7 +324,6 @@ function install_script_module {
         ;;
       --enable-retries)
         retry_number="$DEFAULT_FETCH_RETRY_NUMBER"
-        shift
         ;;
       --help)
         print_usage

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -14,6 +14,9 @@ readonly MODULE_INSTALL_FILE_NAME="install.sh"
 readonly DEFAULT_MODULES_DOWNLOAD_DIR="/tmp/gruntwork-script-modules"
 readonly DEFAULT_BIN_DIR="/usr/local/bin"
 
+readonly DEFAULT_RETRY_NUMBER=0
+readonly DEFAULT_FETCH_RETRY_NUMBER=10
+
 function print_usage {
   echo
   echo "Usage: gruntwork-install [OPTIONS]"
@@ -39,6 +42,7 @@ function print_usage {
   echo -e "  --binary-install-dir\tThe directory to which the binary will be installed. Only applies to binaries (not modules). Default: $DEFAULT_BIN_DIR"
   echo -e "  --no-sudo\t\tWhen true, don't use sudo to install the binary into the install directory. Only applies to binaries (not modules). Default: false"
   echo -e "  --branch\t\tDownload the latest commit from this branch in --repo. This is an alternative to --tag, used only for testing."
+  echo -e "  --enable-retries\t\tEnable retry logic in all downloads, where possible."
   echo -e "  --help\t\tShow this help text and exit."
 
   echo
@@ -124,6 +128,7 @@ function fetch_script_module {
   local -r branch="$3"
   local -r download_dir="$4"
   local -r repo="$5"
+  local -r retry_number="$6"
 
   # We want to make sure that all folders down to $download_path/$module_name exists, but that $download_path/$module_name itself is empty.
   mkdir -p "$download_dir/$module_name/"
@@ -132,7 +137,7 @@ function fetch_script_module {
   # Note that fetch can safely handle blank arguments for --tag or --branch
   # If both --tag and --branch are specified, --branch will be used
   log_info "Downloading module $module_name from $repo"
-  fetch --repo="$repo" --tag="$tag" --branch="$branch" --source-path="/modules/$module_name" "$download_dir/$module_name"
+  fetch --retries=$retry_number --repo="$repo" --tag="$tag" --branch="$branch" --source-path="/modules/$module_name" "$download_dir/$module_name"
 }
 
 # Download a binary asset from a GitHub release using fetch (https://github.com/gruntwork-io/fetch)
@@ -145,6 +150,7 @@ function fetch_binary {
   local -r sha512_checksum="$6"
   local -r binary_install_dir="$7"
   local -r no_sudo="$8"
+  local -r retry_number="$9"
 
   local binary_name_full=""
   binary_name_full=$(determine_binary_name "$binary_name")
@@ -157,11 +163,11 @@ function fetch_binary {
   rm -f "$download_dir/$binary_name_full"
 
   if [[ -n "$sha256_checksum" ]]; then
-    fetch --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_dir" --release-asset-checksum-algo "sha256" --release-asset-checksum "$sha256_checksum"
+    fetch --retries=$retry_number --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_dir" --release-asset-checksum-algo "sha256" --release-asset-checksum "$sha256_checksum"
    elif [[ -n "$sha512_checksum" ]]; then
-    fetch --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_dir" --release-asset-checksum-algo "sha512" --release-asset-checksum "$sha512_checksum"
+    fetch --retries=$retry_number --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_dir" --release-asset-checksum-algo "sha512" --release-asset-checksum "$sha512_checksum"
   else
-    fetch --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_dir"
+    fetch --retries=$retry_number --repo="$repo" --tag="$tag" --release-asset="$binary_name_full" "$download_dir"
   fi
 
   log_info "Moving $full_download_path to $full_dest_path and setting execute permissions"
@@ -262,6 +268,7 @@ function install_script_module {
   local binary_install_dir="$DEFAULT_BIN_DIR"
   local repo=""
   local download_dir="$DEFAULT_MODULES_DOWNLOAD_DIR"
+  local retry_number="$DEFAULT_RETRY_NUMBER"
   local module_params=()
   local no_sudo="false"
 
@@ -315,6 +322,10 @@ function install_script_module {
         no_sudo="$2"
         shift
         ;;
+      --enable-retries)
+        retry_number="$DEFAULT_FETCH_RETRY_NUMBER"
+        shift
+        ;;
       --help)
         print_usage
         exit
@@ -354,12 +365,12 @@ function install_script_module {
 
   if [[ -n "$module_name" ]]; then
     log_info "Installing from $module_name..."
-    fetch_script_module "$module_name" "$tag" "$branch" "$download_dir" "$repo"
+    fetch_script_module "$module_name" "$tag" "$branch" "$download_dir" "$repo" "$retry_number"
     validate_module "$module_name" "$download_dir" "$tag" "$branch" "$repo"
     run_module "$module_name" "$download_dir" "$tag" "$branch" "${module_params[@]}"
   else
     log_info "Installing $binary_name..."
-    fetch_binary "$binary_name" "$tag" "$download_dir" "$repo" "$binary_sha256_checksum" "$binary_sha512_checksum" "$binary_install_dir" "$no_sudo"
+    fetch_binary "$binary_name" "$tag" "$download_dir" "$repo" "$binary_sha256_checksum" "$binary_sha512_checksum" "$binary_install_dir" "$no_sudo" "$retry_number"
   fi
 
   log_info "Success!"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -10,8 +10,14 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Using local copy of bootstrap installer to install local copy of gruntwork-install"
 ./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
 
+echo "Bootstrap installer can handle retries"
+./src/bootstrap-gruntwork-installer.sh --enable-retries --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
+
 echo "Using gruntwork-install to install a module from the module-ecs repo"
 gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1"
+
+echo "Using gruntwork-install to install a module with retries"
+gruntwork-install --enable-retries --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1"
 
 echo "Using gruntwork-install to install a module from the module-ecs repo with --download-dir option"
 gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1" --download-dir ~/tmp

--- a/test/no-sudo-test.sh
+++ b/test/no-sudo-test.sh
@@ -15,7 +15,8 @@ gruntwork-install \
   --repo "https://github.com/gruntwork-io/gruntkms" \
   --tag "v0.0.1" \
   --binary-install-dir "$HOME" \
-  --no-sudo "true"
+  --no-sudo "true" \
+  --enable-retries
 
 echo "Checking that gruntkms installed correctly into home dir"
 "$HOME/gruntkms" --help


### PR DESCRIPTION
This PR does the initial plumbing in bash for enabling download retries in the installer scripts.

The general philosophy is to rely on the native capabilities of curl (and whatever other tools we use) to do this, rather than (re)implementing it in bash. Notably, this means implementing similar retry logic in fetch, which is a separate PR.