### PR TITLE
Fix CircleCI Contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 defaults: &defaults
   working_directory: /home/circleci/.go_workspace/src/github.com/gruntwork-io/gruntwork-installer
   machine: true
-
 version: 2
 jobs:
   test:
@@ -12,7 +11,6 @@ jobs:
           name: run tests
           command: |
             ./_ci/run-tests.sh
-
 workflows:
   version: 2
   install-and-test:
@@ -21,3 +19,5 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+          context:
+            - Gruntwork Admin


### PR DESCRIPTION
This pull request was programmatically opened by the multi-repo-updater program. It should be adding the 'Gruntwork Admin' context to any Workflows -> Jobs nodes and should also be leaving the rest of the .circleci/config.yml file alone. 

 This PR was opened so that all our repositories' .circleci/config.yml files can be converted to use the same CircleCI context, which will make rotating secrets much easier in the future.