### PR TITLE
Update default fetch version

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -21,7 +21,7 @@ set -e
 readonly BIN_DIR="/usr/local/bin"
 readonly USER_DATA_DIR="/etc/user-data"
 
-readonly DEFAULT_FETCH_VERSION="v0.3.2"
+readonly DEFAULT_FETCH_VERSION="v0.3.13"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 


### PR DESCRIPTION
The latest version of fetch fixes a number of important bugs, including:

- Add support for working with GitHub Enterprise.
- Skip Git tags that don't follow SemVer.
- Add support for pagination on Git tags so that you can fetch older tags in repos with many tags.

The last item is especially important, as we now have more repos with many tags.