### PR TITLE
Update fetch to version with a proper logger

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -21,7 +21,7 @@ set -e
 readonly BIN_DIR="/usr/local/bin"
 readonly USER_DATA_DIR="/etc/user-data"
 
-readonly DEFAULT_FETCH_VERSION="v0.3.14"
+readonly DEFAULT_FETCH_VERSION="v0.4.0"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 

--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -21,7 +21,7 @@ set -e
 readonly BIN_DIR="/usr/local/bin"
 readonly USER_DATA_DIR="/etc/user-data"
 
-readonly DEFAULT_FETCH_VERSION="v0.4.0"
+readonly DEFAULT_FETCH_VERSION="v0.4.1"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 


### PR DESCRIPTION
This PR updates `fetch` to use the proper logger that was added in https://github.com/gruntwork-io/fetch/pull/90 and released in https://github.com/gruntwork-io/fetch/releases/tag/v0.4.0. I've also bumped the version v0.4.1 to include a minor fix for the usage help text.