### PR TITLE
Update all repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,22 @@ Option                      | Required | Description
 ##### Example 1: Download and Install a Script Module with No Parameters
 
 Install the [ecs-scripts
-module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) from the [module-ecs
-repo](https://github.com/gruntwork-io/module-ecs), version `v0.0.1`:
+module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/master/modules/ecs-scripts) from the [terraform-aws-ecs
+repo](https://github.com/gruntwork-io/terraform-aws-ecs), version `v0.0.1`:
 
 ```
-gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag 'v0.0.1'
+gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/terraform-aws-ecs' --tag 'v0.0.1'
 ```
 
 ##### Example 2: Download and Install a Script Module with Parameters
 
 Install the [fail2ban
-module](https://github.com/gruntwork-io/module-security/tree/master/modules/fail2ban) from the [module-security
-repo](https://github.com/gruntwork-io/module-security), passing two custom parameters to it:
+module](https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/fail2ban) from the [terraform-aws-security
+repo](https://github.com/gruntwork-io/terraform-aws-security), passing two custom parameters to it:
 
 
 ```
-gruntwork-install --module-name 'fail2ban' --repo 'module-security' -module-param 'ban-time=3600'
+gruntwork-install --module-name 'fail2ban' --repo 'terraform-aws-security' -module-param 'ban-time=3600'
 ```
 
 ##### Example 3: Download and Install a Binary Module
@@ -119,8 +119,8 @@ and then uses it to install several modules:
     {
       "type": "shell",
       "inline": [
-        "gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag 'v0.0.1'",
-        "gruntwork-install --module-name 'fail2ban' --repo 'https://github.com/gruntwork-io/module-security' -module-param 'ban-time=3600'",
+        "gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/terraform-aws-ecs' --tag 'v0.0.1'",
+        "gruntwork-install --module-name 'fail2ban' --repo 'https://github.com/gruntwork-io/terraform-aws-security' -module-param 'ban-time=3600'",
         "gruntwork-install --binary-name 'gruntkms' --repo 'https://github.com/gruntwork-io/gruntkms' --tag 'v0.0.1'"
       ],
       "environment_vars": ["GITHUB_OAUTH_TOKEN={{user `github_auth_token`}}"]
@@ -194,10 +194,10 @@ it to a GitHub release with the name format `<NAME>_<OS>_<ARCH>`.
 ### Example
 
 For example, in your Packer and Docker templates, you can use `gruntwork-install` to install the [ecs-scripts
-module](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-scripts) as follows:
+module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/master/modules/ecs-scripts) as follows:
 
 ```
-gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/module-ecs' --tag 'v0.0.1'
+gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/terraform-aws-ecs' --tag 'v0.0.1'
 ```
 
 In https://github.com/gruntwork-io/module-ecs, we download the contents of `/modules/ecs-scripts` and run

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -10,11 +10,11 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Using local copy of bootstrap installer to install local copy of gruntwork-install"
 ./src/bootstrap-gruntwork-installer.sh --download-url "$LOCAL_INSTALL_URL" --version "ignored-for-local-install"
 
-echo "Using gruntwork-install to install a module from the module-ecs repo using branch"
-gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1"
+echo "Using gruntwork-install to install a module from the terraform-aws-ecs repo using branch"
+gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/terraform-aws-ecs" --branch "v0.0.1"
 
-echo "Using gruntwork-install to install a module from the module-ecs repo with --download-dir option"
-gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/module-ecs" --branch "v0.0.1" --download-dir ~/tmp
+echo "Using gruntwork-install to install a module from the terraform-aws-ecs repo with --download-dir option"
+gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/terraform-aws-ecs" --branch "v0.0.1" --download-dir ~/tmp
 
 echo "Checking that the ecs-scripts installed correctly"
 configure-ecs-instance --help


### PR DESCRIPTION
_**This PR was created by git-xargs. See https://github.com/gruntwork-io/prototypes/pull/152 for context.**_ We recently renamed all of our repos to follow the Terraform registry format of  (e.g., ). This PR does a search & replace to update all references to these repos to the new names. GitHub can handle redirects, so in theory, everything should work fine with the old names, but there were so many renames, that to reduce confusion, this will update most of our references to the proper values.