### PR TITLE
Use arm64 if arm64

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -132,7 +132,9 @@ function get_os_arch {
 function get_os_arch_gox_format {
   local -r arch=$(get_os_arch)
 
-  if string_contains "$arch" "64"; then
+  if string_contains "$arch" "arm64"; then
+    echo "arm64"
+  elif string_contains "$arch" "64"; then
     echo "amd64"
   elif string_contains "$arch" "386"; then
     echo "386"

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -209,7 +209,9 @@ function string_contains {
 function get_os_arch_gox_format {
   local -r arch=$(get_os_arch)
 
-  if string_contains "$arch" "64"; then
+  if string_contains "$arch" "arm64"; then
+    echo "arm64"
+  elif string_contains "$arch" "64"; then
     echo "amd64"
   elif string_contains "$arch" "386"; then
     echo "386"


### PR DESCRIPTION
Previously we were assuming `amd64` if the arch string contained `64`, but this ignores `arm64` machines like M1 macbook. This fixes that.