### PR TITLE
fix aarch64 fetch install

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -134,6 +134,8 @@ function get_os_arch_gox_format {
 
   if string_contains "$arch" "arm64"; then
     echo "arm64"
+  elif string_contains "$arch" "aarch64"; then
+    echo "arm64"
   elif string_contains "$arch" "64"; then
     echo "amd64"
   elif string_contains "$arch" "386"; then

--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -21,7 +21,7 @@ set -e
 readonly BIN_DIR="/usr/local/bin"
 readonly USER_DATA_DIR="/etc/user-data"
 
-readonly DEFAULT_FETCH_VERSION="v0.4.1"
+readonly DEFAULT_FETCH_VERSION="v0.4.2"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 

--- a/gruntwork-install
+++ b/gruntwork-install
@@ -211,6 +211,8 @@ function get_os_arch_gox_format {
 
   if string_contains "$arch" "arm64"; then
     echo "arm64"
+  elif string_contains "$arch" "aarch64"; then
+    echo "arm64"
   elif string_contains "$arch" "64"; then
     echo "amd64"
   elif string_contains "$arch" "386"; then


### PR DESCRIPTION
## Problem

* `uname -m` returns `aarch64` on EKS ARM AMIs which causes `get_os_arch_gox_format` to return `amd64` rather than `arm64`
* fetch `0.4.1` has no ARM build

## Solution

* add case for `aarch64` returning `arm64`
* bump fetch version

Tested on x86 + ARM builds