### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ repo](https://github.com/gruntwork-io/terraform-aws-security), passing two custo
 
 
 ```
-gruntwork-install --module-name 'fail2ban' --repo 'terraform-aws-security' -module-param 'ban-time=3600'
+gruntwork-install --module-name 'fail2ban' --repo 'terraform-aws-security' --module-param 'ban-time=3600'
 ```
 
 ##### Example 3: Download and Install a Binary Module


### PR DESCRIPTION
## Description

There is a minor typo in README.md that could derail some folks (aka me).

`-module-param` isn't supported, but `--module-param` is.

### Documentation

N/A

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

N/A
