### PR TITLE
Output a Deprecation Notice on old branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_gruntwork_installer)
 # Gruntwork Installer
 
-`gruntwork-install` is a bash script you run to easily download and install "Gruntwork Modules".
+`gruntwork-install` is a bash script you run to easily download and install Gruntwork Modules.
 
 ## Compatibility
 
-Tested under CentOS 7, latest Amazon Linux and Ubuntu 16.04.
+Tested under CentOS 7, latest Amazon Linux, and Ubuntu 16.04.
 
 ## Quick Start
 
@@ -17,13 +17,13 @@ Our solution is to make the `gruntwork-install` tool open source and to publish 
 script that anyone can use to install `gruntwork-install` itself. To use it, execute the following:
 
 ```
-curl -LsS https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.38
+curl -LsS https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.38
 ```
 
 Notice the `--version` parameter at the end where you specify which version of `gruntwork-install` to install. See the
 [releases](https://github.com/gruntwork-io/gruntwork-installer/releases) page for all available versions.
 
-For paranoid security folks, see [is it safe to pipe URLs into bash?](#is-it-safe-to-pipe-urls-into-bash) below.
+For those concerned about security, see [is it safe to pipe URLs into bash?](#is-it-safe-to-pipe-urls-into-bash) below.
 
 ### Use gruntwork-install
 
@@ -62,7 +62,7 @@ Option                      | Required | Description
 ##### Example 1: Download and Install a Script Module with No Parameters
 
 Install the [ecs-scripts
-module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/master/modules/ecs-scripts) from the [terraform-aws-ecs
+module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts) from the [terraform-aws-ecs
 repo](https://github.com/gruntwork-io/terraform-aws-ecs), version `v0.0.1`:
 
 ```
@@ -72,7 +72,7 @@ gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwo
 ##### Example 2: Download and Install a Script Module with Parameters
 
 Install the [fail2ban
-module](https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/fail2ban) from the [terraform-aws-security
+module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/fail2ban) from the [terraform-aws-security
 repo](https://github.com/gruntwork-io/terraform-aws-security), passing two custom parameters to it:
 
 
@@ -117,7 +117,7 @@ and then uses it to install several modules:
     {
       "type": "shell",
       "inline":
-        "curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.16"
+        "curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.16"
     },
     {
       "type": "shell",
@@ -175,13 +175,14 @@ Some Script Modules are so common that we've made them freely available in the [
 
 ### How `gruntwork-install` Works
 
-To actually install a Gruntwork Module, we wrote a bash script named `gruntwork-install`. Here's how it works:
+`gruntwork-install` helps you install a Gruntwork Module. Here's how it works:
 
 1. It uses [fetch](https://github.com/gruntwork-io/fetch) to download the specified version of the scripts or binary from
    the (public or private) git repo specified via the `--repo` option.
-1. If you used the `--module-name` parameter, it downloads the files from the `modules` folder of `--repo` and runs
+1. You need to specify either a module name or a binary name. 
+    - If you use the `--module-name` parameter, it downloads the files from the `modules` folder of `--repo` and runs
    the `install.sh` script of that module.
-1. If you used the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
+    - If you use the `--binary-name` parameter, it downloads the right binary for your OS, copies it to `/usr/local/bin`,
    and gives it execute permissions.
 
 That's it!
@@ -197,7 +198,7 @@ it to a GitHub release with the name format `<NAME>_<OS>_<ARCH>`.
 ### Example
 
 For example, in your Packer and Docker templates, you can use `gruntwork-install` to install the [ecs-scripts
-module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/master/modules/ecs-scripts) as follows:
+module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts) as follows:
 
 ```
 gruntwork-install --module-name 'ecs-scripts' --repo 'https://github.com/gruntwork-io/terraform-aws-ecs' --tag 'v0.0.1'

--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -220,10 +220,11 @@ EOF
 }
 
 function warn {
-  echo "⚠️: Warning: You're installing this tool from the `master` branch, which will be removed February 1, 2023."
-  echo "   Please instead use a tagged release."
-  echo "   E.g.:"
-  echo "   curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh"
+  echo "--------------------------------------------------------------------------------------------------------------"
+  echo "⚠️: Warning: You're installing this tool from the 'master' branch, which will be removed February 1, 2023."
+  echo "   Please instead use a tagged release. E.g.:"
+  echo "   curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.38"
+  echo "--------------------------------------------------------------------------------------------------------------"
 }
 
 function bootstrap {

--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -2,19 +2,21 @@
 #
 # A bootstrap script to install the Gruntwork Installer.
 #
-# Why:
+# Usage:
 #
-# The goal of the Gruntwork Installer is to make make installing Gruntwork Script Modules feel as easy as installing a
-# package using apt-get, brew, or yum. However, something has to install the Gruntwork Installer first. One option is
-# for each Gruntwork client to do so manually, which would basically entail copying and pasting all the code below.
-# This is tedious and would give us no good way to push updates to this bootstrap script.
+# curl -LsS https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.38
 #
-# So instead, we recommend that clients use this tiny bootstrap script as a one-liner:
+# Rationale:
 #
-# curl -LsS https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.38
+# The Gruntwork Installer makes installing Gruntwork Script Modules as easy as installing a package using apt-get, 
+# brew, or yum. However, something has to install the Gruntwork Installer first. One option is for each Gruntwork 
+# client to do so manually, which would basically entail copying and pasting all the code below. This is tedious and 
+# gives us no good way to push updates to this bootstrap script.
 #
-# You can copy this one-liner into your Packer and Docker templates and immediately after, start using the
-# gruntwork-install command.
+# So instead, we recommend that clients use this tiny bootstrap script.
+#
+# In your Packer and Docker templates, you can use the above one-liner to install the Gruntwork Installer, and then
+# start using the `gruntwork-install` command immediately.
 
 set -e
 
@@ -37,19 +39,19 @@ function print_usage {
   echo
   echo "Options:"
   echo
-  echo -e "  --version\t\tRequired. The version of $GRUNTWORK_INSTALLER_SCRIPT_NAME to install (e.g. 0.0.3)."
+  echo -e "  --version\t\tRequired. The version of $GRUNTWORK_INSTALLER_SCRIPT_NAME to install (e.g. v0.0.38)."
   echo -e "  --fetch-version\tOptional. The version of fetch to install. Default: $DEFAULT_FETCH_VERSION."
   echo -e "  --user-data-owner\tOptional. The user who shown own the $USER_DATA_DIR folder. Default: (current user)."
   echo -e "  --download-url\tOptional. The URL from where to download $GRUNTWORK_INSTALLER_SCRIPT_NAME. Mostly used for automated tests. Default: $GRUNTWORK_INSTALLER_DOWNLOAD_URL_BASE/(version)/$GRUNTWORK_INSTALLER_SCRIPT_NAME."
-  echo -e "  --no-sudo\tOptional. When true, don't use sudo to install binaries. Default: false"
+  echo -e "  --no-sudo\tOptional. When true, don't use sudo to install binaries. Default: false."
   echo
   echo "Examples:"
   echo
-  echo "  Install version 0.0.3:"
-  echo "    bootstrap-gruntwork-installer.sh --version 0.0.3"
+  echo "  Install version v0.0.38:"
+  echo "    bootstrap-gruntwork-installer.sh --version v0.0.38"
   echo
-  echo "  One-liner to download this bootstrap script from GitHub and run it to install version 0.0.3:"
-  echo "    curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.3"
+  echo "  One-liner to download this bootstrap script from GitHub and run it to install version v0.0.38:"
+  echo "    curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.38"
 }
 
 function maybe_sudo {
@@ -217,7 +219,15 @@ EOF
   maybe_sudo "$no_sudo" chown -R "$user_data_folder_owner" "$user_data_folder"
 }
 
+function warn {
+  echo "⚠️: Warning: You're installing this tool from the `master` branch, which will be removed February 1, 2023."
+  echo "   Please instead use a tagged release."
+  echo "   E.g.:"
+  echo "   curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh"
+}
+
 function bootstrap {
+  warn
   local fetch_version="$DEFAULT_FETCH_VERSION"
   local installer_version=""
   local download_url=""

--- a/examples/packer-file-copy/packer-example.json
+++ b/examples/packer-file-copy/packer-example.json
@@ -27,7 +27,7 @@
     "destination": "/tmp/packer-files"
   },{
     "type": "shell",
-    "inline": "curl -LsS https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version {{user `gruntwork_installer_version`}}"
+    "inline": "curl -LsS https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/v0.0.38/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version {{user `gruntwork_installer_version`}}"
   },{
     "type": "shell",
     "inline": [


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Addresses part of https://github.com/gruntwork-io/cloud-chasers/issues/32

We've updated the default branch of this repo to `main`. However we still have a copy of the old default branch that we are allowing to get stale. No updates after this PR should be merged into it. We will delete that branch on February 1, 2023.

Note: This PR will be merged onto the old default branch, not `main`.

When someone uses the old default branch, they'll see this notice:

![image](https://user-images.githubusercontent.com/13165182/186195931-90d4c36e-c7ac-4903-adcd-583b47987dab.png)

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added a deprecation notice warning users to specify a tagged release. We've updated the default branch to `main`. **NOTE**: We will delete the old default branch, `master`, on February 1, 2023, to allow a (hopefully generous) transition time.