### PR TITLE
bootstrap: allow user to override BIN_DIR & USER_DATA_DIR

### DIFF
--- a/bootstrap-gruntwork-installer.sh
+++ b/bootstrap-gruntwork-installer.sh
@@ -20,8 +20,8 @@
 
 set -e
 
-readonly BIN_DIR="/usr/local/bin"
-readonly USER_DATA_DIR="/etc/user-data"
+readonly BIN_DIR="${GRUNTWORK_BIN_DIR:-/usr/local/bin}"
+readonly USER_DATA_DIR="${GRUNTWORK_USER_DATA_DIR:-/etc/user-data}"
 
 readonly DEFAULT_FETCH_VERSION="v0.4.6"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"


### PR DESCRIPTION
## Description

- Fixes #87
- Probably fixes #17

This tiny enhancement allows a user to specify alternate locations for the binaries and user-data. Overriding these values to a location where the user has write privileges will allow this script to run without root permissions.

It is probably an uncommon use case, and an advanced user should quickly notice these optional overrides when reviewing the script since they're at the very beginning. For this reason, I did not add a CLI parameter nor documentation.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if it's not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added optional overrides for BIN_DIR and USER_DATA_DIR

### Migration Guide

not applicable
