### PR TITLE
Support flags

### DIFF
--- a/gruntwork-install
+++ b/gruntwork-install
@@ -310,9 +310,13 @@ function install_script_module {
         shift
         ;;
       --module-param)
-        local module_param_key="${2%%=*}"
-        local module_param_val="${2#*=}"
-        module_params+=( "--$module_param_key" "$module_param_val" )
+        if [[ $2 == *"="* ]]; then
+          local module_param_key="${2%%=*}"
+          local module_param_val="${2#*=}"
+          module_params+=( "--$module_param_key" "$module_param_val" )
+        else
+          module_params+=( "--$2" )
+        fi
         shift
         ;;
       --download-dir)

--- a/modules/mixed-args-module/README.md
+++ b/modules/mixed-args-module/README.md
@@ -1,0 +1,3 @@
+# Mixed args module
+
+This module is used solely for running automated tests against the Gruntwork Installer. 

--- a/modules/mixed-args-module/install.sh
+++ b/modules/mixed-args-module/install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# A dirt simple install script that expects one madatory argument, --message-to-echo, that it echoes. The echo message can be overridden with 
+# a flag, --echo-override. This is used to test that the --module-param args in gruntwork-install can handle flags without values.
+
+set -e
+
+function assert_not_empty {
+  local -r arg_name="$1"
+  local -r arg_value="$2"
+
+  if [[ -z "$arg_value" ]]; then
+    echo "ERROR: The value for '$arg_name' cannot be empty"
+    exit 1
+  fi
+}
+
+function install {
+  local echomessage
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+
+    case "$key" in
+      --message-to-echo)
+        echomessage="$2"
+        shift
+        ;;
+      --echo-override)
+        echomessage="Override"
+        ;;
+      *)
+        echo "Unrecognized argument: $key"
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  assert_not_empty "--message-to-echo" "$echomessage"
+  echo "$echomessage"
+}
+
+install "$@"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -22,6 +22,9 @@ configure-ecs-instance --help
 echo "Using gruntwork-install to install a module from the gruntwork-install repo and passing args to it via --module-param"
 gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --tag "v0.0.25" --module-param "file-to-cat=$SCRIPT_DIR/integration-test.sh"
 
+echo "Using gruntwork-install to install a module from the gruntwork-install repo and passing mixed args to it via --module-param"
+gruntwork-install --module-name "mixed-args-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --ref "fix/mixed-args" --module-param "message-to-echo=Hello" --module-param "echo-override"
+
 echo "Using gruntwork-install to install a module from the gruntwork-install repo with branch as ref"
 gruntwork-install --module-name "dummy-module" --repo "https://github.com/gruntwork-io/gruntwork-installer" --ref "for-testing-dont-delete" --module-param "file-to-cat=$SCRIPT_DIR/integration-test.sh"
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #91 

Properly handle flags when processing `--module-param`. Previously a flag that was passed like this: `--module-param flag` ended up like this: `--flag flag`. With this change it is properly passed as just `--flag`. 

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if it's not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
